### PR TITLE
Forward ingress authentication to nifi

### DIFF
--- a/helm/idol-nifi/templates/nifi/ingress.yaml
+++ b/helm/idol-nifi/templates/nifi/ingress.yaml
@@ -35,6 +35,10 @@ metadata:
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: nifi-basic-auth
     nginx.ingress.kubernetes.io/auth-realm: "Authentication Required"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      server_tokens off;
+      proxy_pass_header Authorization;
+      proxy_set_header Authorization $http_authorization;
 {{- else if eq .Values.ingressType "haproxy" }}
     haproxy.router.openshift.io/rewrite-target: / 
     haproxy.router.openshift.io/proxy-body-size: {{ .Values.ingressProxyBodySize }}


### PR DESCRIPTION
The NiFi UI makes NiFi API requests, and so requires the authorization header used to authenticate with the ingress point.
Resolves issue where a 401 error can be seen when using some UI features, e.g. purge datastore