### PR TITLE
Generate sensitive props key & trust/keystore pass

### DIFF
--- a/helm/idol-nifi/templates/nifi/_container.tpl
+++ b/helm/idol-nifi/templates/nifi/_container.tpl
@@ -55,6 +55,9 @@ envFrom:
   - configMapRef:
       name: idol-nifi-env
       optional: false
+  - configMapRef:
+      name: idol-nifi-keys-env
+      optional: false
 lifecycle:
   postStart:
     exec:

--- a/helm/idol-nifi/templates/nifi/configmap-keys.yaml
+++ b/helm/idol-nifi/templates/nifi/configmap-keys.yaml
@@ -1,0 +1,20 @@
+# BEGIN COPYRIGHT NOTICE
+# Copyright 2023 Open Text.
+# 
+# The only warranties for products and services of Open Text and its affiliates and licensors
+# ("Open Text") are as may be set forth in the express warranty statements accompanying such
+# products and services. Nothing herein should be construed as constituting an additional warranty.
+# Open Text shall not be liable for technical or editorial errors or omissions contained herein.
+# The information contained herein is subject to change without notice.
+#
+# END COPYRIGHT NOTICE
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: idol-nifi-keys-env
+  labels: {{- include "idol-library.labels" (dict "root" . "component" .Values.nifi) | nindent 4 -}}
+    app: nifi
+data:
+  KEYSTORE_PASSWORD: {{ .Values.nifi.keystorePassword | default (randAlphaNum 24) | quote }}
+  NIFI_SENSITIVE_PROPS_KEY: {{ .Values.nifi.sensitivePropsKey | default (randAlphaNum 24) | quote }}
+  TRUSTSTORE_PASSWORD: {{ .Values.nifi.truststorePassword | default (randAlphaNum 24) | quote }}

--- a/helm/idol-nifi/templates/nifi/configmap.yaml
+++ b/helm/idol-nifi/templates/nifi/configmap.yaml
@@ -17,7 +17,7 @@ metadata:
 data:
   JAVA_HOME: "/usr/lib/jvm/jre-11"
   JAVA_OPTS: "-XX:UseAVX=0 -Djavax.net.debug=ssl,handshake"
-  KEYSTORE_PASSWORD: "th1s1s3up34e5r37"
+  KEYSTORE_PASSWORD: {{ .Values.nifi.keystorePassword | default (randAlphaNum 24) | quote }}
   KEYSTORE_PATH: "${NIFI_HOME}/keytool/keystore.p12"
   KEYSTORE_TYPE: "PKCS12"
   NIFI_ANALYTICS_PREDICT_ENABLED: "true"
@@ -41,8 +41,7 @@ data:
   NIFI_SECURITY_AUTORELOAD_ENABLED: "true"
   NIFI_SECURITY_AUTORELOAD_INTERVAL: "5 min"
   NIFI_SECURITY_NEEDCLIENTAUTH: "true"
-  NIFI_SENSITIVE_PROPS_KEY_PROTECTED: "th1s1s3up34e5r37"
-  NIFI_SENSITIVE_PROPS_KEY: "th1s1s3up34e5r37"
+  NIFI_SENSITIVE_PROPS_KEY: {{ .Values.nifi.sensitivePropsKey | default (randAlphaNum 24) | quote }}
   NIFI_WEB_HTTP_PORT: "8080"
   NIFI_WEB_HTTPS_PORT: "8443"
 {{- if .Values.nifi.ingress.proxyPath }}
@@ -54,7 +53,7 @@ data:
   NIFI_ZK_CONNECT_STRING: "zookeeper:2181"
   NIFI_ZOOKEEPER_CONNECT_STRING: "zookeeper:2181"
   NIFI_REGISTRY_HOSTS: nifi-registry
-  TRUSTSTORE_PASSWORD: "th1s1s3up34e5r37"
+  TRUSTSTORE_PASSWORD: {{ .Values.nifi.truststorePassword | default (randAlphaNum 24) | quote }}
   TRUSTSTORE_PATH: "${NIFI_HOME}/keytool/truststore.jks"
   TRUSTSTORE_TYPE: "jks"
   IDOL_NIFI_FLOWFILE: {{ .Values.nifi.flowfile | quote }}

--- a/helm/idol-nifi/templates/nifi/configmap.yaml
+++ b/helm/idol-nifi/templates/nifi/configmap.yaml
@@ -17,7 +17,6 @@ metadata:
 data:
   JAVA_HOME: "/usr/lib/jvm/jre-11"
   JAVA_OPTS: "-XX:UseAVX=0 -Djavax.net.debug=ssl,handshake"
-  KEYSTORE_PASSWORD: {{ .Values.nifi.keystorePassword | default (randAlphaNum 24) | quote }}
   KEYSTORE_PATH: "${NIFI_HOME}/keytool/keystore.p12"
   KEYSTORE_TYPE: "PKCS12"
   NIFI_ANALYTICS_PREDICT_ENABLED: "true"
@@ -41,7 +40,6 @@ data:
   NIFI_SECURITY_AUTORELOAD_ENABLED: "true"
   NIFI_SECURITY_AUTORELOAD_INTERVAL: "5 min"
   NIFI_SECURITY_NEEDCLIENTAUTH: "true"
-  NIFI_SENSITIVE_PROPS_KEY: {{ .Values.nifi.sensitivePropsKey | default (randAlphaNum 24) | quote }}
   NIFI_WEB_HTTP_PORT: "8080"
   NIFI_WEB_HTTPS_PORT: "8443"
 {{- if .Values.nifi.ingress.proxyPath }}
@@ -53,7 +51,6 @@ data:
   NIFI_ZK_CONNECT_STRING: "zookeeper:2181"
   NIFI_ZOOKEEPER_CONNECT_STRING: "zookeeper:2181"
   NIFI_REGISTRY_HOSTS: nifi-registry
-  TRUSTSTORE_PASSWORD: {{ .Values.nifi.truststorePassword | default (randAlphaNum 24) | quote }}
   TRUSTSTORE_PATH: "${NIFI_HOME}/keytool/truststore.jks"
   TRUSTSTORE_TYPE: "jks"
   IDOL_NIFI_FLOWFILE: {{ .Values.nifi.flowfile | quote }}

--- a/helm/idol-nifi/templates/nifi/nifi.yaml
+++ b/helm/idol-nifi/templates/nifi/nifi.yaml
@@ -34,6 +34,9 @@ spec:
         - configMapRef:
             name: idol-nifi-env
             optional: false
+        - configMapRef:
+            name: idol-nifi-keys-env
+            optional: false
         {{- if $component.containerSecurityContext.enabled }}
         securityContext: {{- omit $component.containerSecurityContext "enabled" | toYaml | nindent 10 }}
           readOnlyRootFilesystem: true
@@ -66,6 +69,9 @@ spec:
         envFrom:
         - configMapRef:
             name: idol-nifi-env
+            optional: false
+        - configMapRef:
+            name: idol-nifi-keys-env
             optional: false
         resources:
           requests:

--- a/helm/idol-nifi/values.schema.json
+++ b/helm/idol-nifi/values.schema.json
@@ -154,6 +154,15 @@
                 },
                 "ingress": {
                     "$ref": "#/definitions/NifiIngress"
+                },
+                "keystorePassword": {
+                    "type":"string"
+                },
+                "truststorePassword": {
+                    "type":"string"
+                },
+                "sensitivePropsKey": {
+                    "type":"string"
                 }
             },
             "required": [

--- a/helm/idol-nifi/values.yaml
+++ b/helm/idol-nifi/values.yaml
@@ -157,6 +157,13 @@ nifi:
     # -- optional ingress host https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     aciHost: ""
 
+  # -- optional nifi.security.keystorePasswd value (see https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#security_properties)
+  keystorePassword: ""
+  # -- optional nifi.security.truststorePasswd value (see https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#security_properties)
+  truststorePassword: ""
+  # -- optional nifi.sensitive.props.key value (see https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#nifi_sensitive_props_key)
+  sensitivePropsKey: ""
+
 nifiRegistry:
   ingress:
     # nifiRegistry.ingress.enabled -- whether to deploy ingress for nifi

--- a/helm/idol-nifi/values.yaml
+++ b/helm/idol-nifi/values.yaml
@@ -158,10 +158,13 @@ nifi:
     aciHost: ""
 
   # -- optional nifi.security.keystorePasswd value (see https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#security_properties)
+  # Setting this value is recommended. If it is not set, it will default to a generated value
   keystorePassword: ""
   # -- optional nifi.security.truststorePasswd value (see https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#security_properties)
+  # Setting this value is recommended. If it is not set, it will default to a generated value
   truststorePassword: ""
   # -- optional nifi.sensitive.props.key value (see https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#nifi_sensitive_props_key)
+  # Setting this value is recommended. If it is not set, it will default to a generated value
   sensitivePropsKey: ""
 
 nifiRegistry:


### PR DESCRIPTION
If not specifed in the values.yaml, generate default values for:
- nifi.security.keystorePasswd
- nifi.security.truststorePasswd
- nifi.sensitive.props.key