### PR TITLE
Automate helm chart version updates

### DIFF
--- a/helm/Makefile
+++ b/helm/Makefile
@@ -21,6 +21,7 @@ SKIP_PACKAGE_CHARTS:=idol-library-example-test
 CLEAN_CHARTS:=$(addprefix clean-,${CHARTS})
 PACKAGE_CHARTS:=$(addprefix package-,$(filter-out ${SKIP_PACKAGE_CHARTS},${CHARTS}))
 VALIDATE_SCHEMA_CHARTS:=$(addprefix validateschema-,${SCHEMA_CHARTS})
+UPDATE_VERSIONS_CHARTS:=$(addprefix updateversions-,${CHARTS})
 
 PYTHON_CMD?=python3
 
@@ -30,9 +31,13 @@ THIS_YEAR?=$(shell date +%Y)
 
 UPDATE_DEPENDENCIES?=-u
 
+UPDATE_VERSIONS_DRY_RUN?=
+UPDATE_VERSIONS_DECREMENT?=
+
 .PHONY: package-all ${PACKAGE_CHARTS} 
 .PHONY: clean-all ${CLEAN_CHARTS} 
 .PHONY: validate-all ${VALIDATE_SCHEMA_CHARTS}
+.PHONY: updateversions-all ${UPDATE_VERSIONS_CHARTS}
 
 default: package-all index.yaml
 
@@ -69,6 +74,12 @@ ${VALIDATE_SCHEMA_CHARTS}: validateschema-%: utils/validate.schema.py
 $(addprefix package-,${SCHEMA_CHARTS}): package-% : validateschema-%
 
 validate-all: ${VALIDATE_SCHEMA_CHARTS}
+
+# update chart versions
+${UPDATE_VERSIONS_CHARTS}: updateversions-%: utils/updateversions.py
+	${PYTHON_CMD} utils/updateversions.py $* $(UPDATE_VERSIONS_DRY_RUN) $(UPDATE_VERSIONS_DECREMENT)
+
+updateversions-all: ${UPDATE_VERSIONS_CHARTS}
 
 ${CLEAN_CHARTS}: clean-% : 
 	-${RM} $*/charts/*

--- a/helm/Makefile
+++ b/helm/Makefile
@@ -21,7 +21,6 @@ SKIP_PACKAGE_CHARTS:=idol-library-example-test
 CLEAN_CHARTS:=$(addprefix clean-,${CHARTS})
 PACKAGE_CHARTS:=$(addprefix package-,$(filter-out ${SKIP_PACKAGE_CHARTS},${CHARTS}))
 VALIDATE_SCHEMA_CHARTS:=$(addprefix validateschema-,${SCHEMA_CHARTS})
-UPDATE_VERSIONS_CHARTS:=$(addprefix updateversions-,${CHARTS})
 
 PYTHON_CMD?=python3
 
@@ -31,13 +30,17 @@ THIS_YEAR?=$(shell date +%Y)
 
 UPDATE_DEPENDENCIES?=-u
 
+# update-versions parameters
+# Can overwrite UPDATE_VERSIONS_CHARTS to specify which charts to update
+# Will update all chart versions by default
+UPDATE_VERSIONS_CHARTS ?= $(CHARTS)
 UPDATE_VERSIONS_DRY_RUN?=
 UPDATE_VERSIONS_DECREMENT?=
 
 .PHONY: package-all ${PACKAGE_CHARTS} 
 .PHONY: clean-all ${CLEAN_CHARTS} 
 .PHONY: validate-all ${VALIDATE_SCHEMA_CHARTS}
-.PHONY: updateversions-all ${UPDATE_VERSIONS_CHARTS}
+.PHONY: update-versions
 
 default: package-all index.yaml
 
@@ -76,10 +79,8 @@ $(addprefix package-,${SCHEMA_CHARTS}): package-% : validateschema-%
 validate-all: ${VALIDATE_SCHEMA_CHARTS}
 
 # update chart versions
-${UPDATE_VERSIONS_CHARTS}: updateversions-%: utils/updateversions.py
-	${PYTHON_CMD} utils/updateversions.py $* $(UPDATE_VERSIONS_DRY_RUN) $(UPDATE_VERSIONS_DECREMENT)
-
-updateversions-all: ${UPDATE_VERSIONS_CHARTS}
+update-versions:
+	${PYTHON_CMD} utils/updateversions.py --charts $(UPDATE_VERSIONS_CHARTS) $(UPDATE_VERSIONS_DRY_RUN) $(UPDATE_VERSIONS_DECREMENT)
 
 ${CLEAN_CHARTS}: clean-% : 
 	-${RM} $*/charts/*

--- a/helm/utils/updateversions.py
+++ b/helm/utils/updateversions.py
@@ -51,7 +51,6 @@ def update_dependencies(chart_dir: str, updated_versions: dict, dependency_graph
     if 'dependencies' in chart_yaml:
         for dep in chart_yaml['dependencies']:
             # only update dependency version if it's the latest one 
-            #print(dependency_graph.keys())
             if dep['name'] in updated_versions and dep['version'] == dependency_graph[dep['name']]['version']:
                 dep['version'] = updated_versions[dep['name']]
             elif dep['name'] in updated_versions and dep['name'] in dependency_graph:

--- a/helm/utils/updateversions.py
+++ b/helm/utils/updateversions.py
@@ -51,8 +51,11 @@ def update_dependencies(chart_dir: str, updated_versions: dict, dependency_graph
     if 'dependencies' in chart_yaml:
         for dep in chart_yaml['dependencies']:
             # only update dependency version if it's the latest one 
+            #print(dependency_graph.keys())
             if dep['name'] in updated_versions and dep['version'] == dependency_graph[dep['name']]['version']:
                 dep['version'] = updated_versions[dep['name']]
+            elif dep['name'] in updated_versions and dep['name'] in dependency_graph:
+                print(f"Didn't update version for {chart_dir} dependency {dep['name']}: dependency version ({dep['version']}) is not latest one ({dependency_graph[dep['name']]['version']})")
         
         if not dry_run:
             with open(chart_yaml_path, 'w') as f:

--- a/helm/utils/updateversions.py
+++ b/helm/utils/updateversions.py
@@ -75,7 +75,7 @@ def get_dependent_charts(graph: dict, chart_dir: str, latest_version: str):
             dependent_charts.append(key)
     return dependent_charts
 
-def update_charts(chart_dir: str, dry_run: bool, decrement: bool):
+def update_charts(chart_dirs: list, dry_run: bool, decrement: bool):
     dependency_graph = build_dependency_graph()
     updated_versions = {}
     charts_processed = set()
@@ -98,7 +98,8 @@ def update_charts(chart_dir: str, dry_run: bool, decrement: bool):
         for dependent in dependents:
             process_chart(dependent)
 
-    process_chart(chart_dir)
+    for chart_dir in chart_dirs:
+        process_chart(chart_dir)
 
     # update dependencies for all processed charts
     for processed_chart in charts_processed:
@@ -106,7 +107,7 @@ def update_charts(chart_dir: str, dry_run: bool, decrement: bool):
         
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Update Helm chart versions.')
-    parser.add_argument('chart', help='Name of the chart to update, including all charts depending on it', type=str)
+    parser.add_argument('--charts', nargs='+', required=True, help='Names of the charts to update')
     parser.add_argument('--dry-run', action='store_true', help='prints updates that would occur, but does not actually modify any files')
     parser.add_argument('--decrement', action='store_true', help='decrement version numbers instead of incrementing them')
     args = parser.parse_args()
@@ -121,4 +122,4 @@ if __name__ == '__main__':
             return dumper.represent_scalar('tag:yaml.org,2002:str', data)
         yaml.representer.add_representer(str, str_presenter)
 
-    update_charts(args.chart, args.dry_run, args.decrement)
+    update_charts(args.charts, args.dry_run, args.decrement)

--- a/helm/utils/updateversions.py
+++ b/helm/utils/updateversions.py
@@ -1,0 +1,124 @@
+import os
+import argparse
+
+from ruamel.yaml import YAML
+
+yaml = YAML()
+yaml.preserve_quotes = True
+yaml.indent(mapping=2, sequence=2, offset=0)
+yaml.width = 4096  # prevents line wrapping
+
+HELM_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..')
+
+# may need to change this in future if version conventions change
+def increment_version(version: str, modifier: int):
+    version_split = version.split('.')
+    version_split[1] = str(int(version_split[1])+modifier)
+    return '.'.join(version_split)
+
+def get_chart_version(chart_dir: str):
+    chart_yaml_path = os.path.join(HELM_DIR, chart_dir, 'Chart.yaml')
+    with open(chart_yaml_path, 'r') as f:
+        chart_yaml = yaml.load(f)
+    return chart_yaml['version']
+
+def update_chart_version(chart_dir: str, dry_run: bool, modifier: int):
+    chart_yaml_path = os.path.join(HELM_DIR, chart_dir, 'Chart.yaml')
+    with open(chart_yaml_path, 'r') as f:
+        chart_yaml = yaml.load(f)
+    
+    chart_yaml['version'] = increment_version(chart_yaml['version'], modifier)
+    
+    if not dry_run:
+        with open(chart_yaml_path, 'w') as f:
+            yaml.dump(chart_yaml, f)
+        
+    return chart_yaml['name'], chart_yaml['version']
+
+def get_dependencies(chart_dir: str):
+    chart_yaml_path = os.path.join(HELM_DIR, chart_dir, 'Chart.yaml')
+    with open(chart_yaml_path, 'r') as f:
+        chart_yaml = yaml.load(f)
+    if 'dependencies' in chart_yaml:
+        return {dep['name']: dep['version'] for dep in chart_yaml['dependencies']}
+    return {}  # no dependencies for this chart
+
+def update_dependencies(chart_dir: str, updated_versions: dict, dependency_graph: dict, dry_run: bool):
+    chart_yaml_path = os.path.join(HELM_DIR, chart_dir, 'Chart.yaml')
+    with open(chart_yaml_path, 'r') as f:
+        chart_yaml = yaml.load(f)
+
+    if 'dependencies' in chart_yaml:
+        for dep in chart_yaml['dependencies']:
+            # only update dependency version if it's the latest one 
+            if dep['name'] in updated_versions and dep['version'] == dependency_graph[dep['name']]['version']:
+                dep['version'] = updated_versions[dep['name']]
+        
+        if not dry_run:
+            with open(chart_yaml_path, 'w') as f:
+                yaml.dump(chart_yaml, f)
+
+def build_dependency_graph():
+    graph = {}
+    for chart_dir in os.listdir(HELM_DIR):
+        if os.path.exists(os.path.join(HELM_DIR, chart_dir, 'Chart.yaml')):
+            chart_version = get_chart_version(chart_dir)
+            # include version so that we only update charts using the latest versions of updated charts
+            graph[chart_dir] = {'version': chart_version, 'dependencies': get_dependencies(chart_dir)}
+    return graph
+
+def get_dependent_charts(graph: dict, chart_dir: str, latest_version: str):
+    dependent_charts = []
+    for key, value in graph.items():
+        # only add the chart to the dependency list if it is the latest version
+        if chart_dir in value['dependencies'] and value['dependencies'][chart_dir] == latest_version:
+            dependent_charts.append(key)
+    return dependent_charts
+
+def update_charts(chart_dir: str, dry_run: bool, decrement: bool):
+    dependency_graph = build_dependency_graph()
+    updated_versions = {}
+    charts_processed = set()
+    modifier = -1 if decrement else 1
+
+    def process_chart(chart_dir: str):
+        if chart_dir in charts_processed:
+            # don't update if already been updated
+            return  
+        # add to processed charts
+        charts_processed.add(chart_dir)
+        
+        # update chart version
+        name, version = update_chart_version(chart_dir, dry_run, modifier)
+        updated_versions[name] = version
+        print(f"Updated {name} to version {version}")
+
+        # update charts that depend on this one and use the latest version
+        dependents = get_dependent_charts(dependency_graph, chart_dir, dependency_graph[chart_dir]['version'])
+        for dependent in dependents:
+            process_chart(dependent)
+
+    process_chart(chart_dir)
+
+    # update dependencies for all processed charts
+    for processed_chart in charts_processed:
+        update_dependencies(processed_chart, updated_versions, dependency_graph, dry_run)
+        
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Update Helm chart versions.')
+    parser.add_argument('chart', help='Name of the chart to update, including all charts depending on it', type=str)
+    parser.add_argument('--dry-run', action='store_true', help='prints updates that would occur, but does not actually modify any files')
+    parser.add_argument('--decrement', action='store_true', help='decrement version numbers instead of incrementing them')
+    args = parser.parse_args()
+
+    if args.dry_run:
+        print("DRY RUN, VERSIONS NOT UPDATED")
+    else:
+        # add the following so that multiline strings are dumped properly
+        def str_presenter(dumper, data):
+            if data.count('\n') > 0:  # check for multiline string
+                return dumper.represent_scalar('tag:yaml.org,2002:str', data, style='|')
+            return dumper.represent_scalar('tag:yaml.org,2002:str', data)
+        yaml.representer.add_representer(str, str_presenter)
+
+    update_charts(args.chart, args.dry_run, args.decrement)


### PR DESCRIPTION
- Script `helm/utils/updateversions.py` which will update the version of a given chart and all charts that depend on it.
- I've implemented it so that versions are only updated for dependencies if they are using the latest version of the chart we're updating, e.g. if we're updating version idol-library from 0.12.0 to 0.13.0, only those charts which use idol-library 0.12.0 will have their versions updated. If a chart is using, e.g. idol-library 0.2.0, it will not be updated.
- I've also added `--dry-run` and `--decrement` flags, which can be set in the Makefile (or by just calling the script directly). They're mainly useful for debugging or if you accidentally increment versions. 