### PR TITLE
Relax idolImage.registry schema

### DIFF
--- a/helm/distributed-idol/values.schema.json
+++ b/helm/distributed-idol/values.schema.json
@@ -175,8 +175,7 @@
             "type": "object",
             "properties":{
                 "registry": {
-                    "type": "string",
-                    "format": "hostname"
+                    "$ref": "#/$defs/required_string"
                 },
                 "version": {
                     "$ref": "#/$defs/required_string"

--- a/helm/idol-answerserver/values.schema.json
+++ b/helm/idol-answerserver/values.schema.json
@@ -126,16 +126,13 @@
             "type": "object",
             "properties":{
                 "registry": {
-                    "type": "string",
-                    "format": "hostname"
+                    "$ref": "#/$defs/required_string"
                 },
                 "version": {
-                    "type": "string",
-                    "minLength": 1
+                    "$ref": "#/$defs/required_string"
                 },
                 "repo": {
-                    "type": "string",
-                    "minLength": 1
+                    "$ref": "#/$defs/required_string"
                 }
             },
             "required":[

--- a/helm/idol-community/values.schema.json
+++ b/helm/idol-community/values.schema.json
@@ -129,8 +129,7 @@
             "type": "object",
             "properties":{
                 "registry": {
-                    "type": "string",
-                    "format": "hostname"
+                    "$ref": "#/$defs/required_string"
                 },
                 "version": {
                     "$ref": "#/$defs/required_string"

--- a/helm/idol-eductionserver/values.schema.json
+++ b/helm/idol-eductionserver/values.schema.json
@@ -114,16 +114,13 @@
             "type": "object",
             "properties":{
                 "registry": {
-                    "type": "string",
-                    "format": "hostname"
+                    "$ref": "#/$defs/required_string"
                 },
                 "version": {
-                    "type": "string",
-                    "minLength": 1
+                    "$ref": "#/$defs/required_string"
                 },
                 "repo": {
-                    "type": "string",
-                    "minLength": 1
+                    "$ref": "#/$defs/required_string"
                 }
             },
             "required":[

--- a/helm/idol-find/values.schema.json
+++ b/helm/idol-find/values.schema.json
@@ -5,7 +5,7 @@
     "properties": {
         "idolImageRegistry": {
             "type": "string",
-            "format": "hostname"
+            "minLength": 1
         },
         "idolVersion": {
             "type": "string",

--- a/helm/idol-library-example-test/values.schema.json
+++ b/helm/idol-library-example-test/values.schema.json
@@ -122,8 +122,7 @@
             "type": "object",
             "properties":{
                 "registry": {
-                    "type": "string",
-                    "format": "hostname"
+                    "$ref": "#/$defs/required_string"
                 },
                 "version": {
                     "$ref": "#/$defs/required_string"

--- a/helm/idol-mediaserver/values.schema.json
+++ b/helm/idol-mediaserver/values.schema.json
@@ -125,16 +125,13 @@
             "type": "object",
             "properties":{
                 "registry": {
-                    "type": "string",
-                    "format": "hostname"
+                    "$ref": "#/$defs/required_string"
                 },
                 "version": {
-                    "type": "string",
-                    "minLength": 1
+                    "$ref": "#/$defs/required_string"
                 },
                 "repo": {
-                    "type": "string",
-                    "minLength": 1
+                    "$ref": "#/$defs/required_string"
                 }
             },
             "required":[

--- a/helm/idol-nifi/values.schema.json
+++ b/helm/idol-nifi/values.schema.json
@@ -96,7 +96,7 @@
             "properties":{
                 "registry": {
                     "type": "string",
-                    "format": "hostname"
+                    "minLength": 1
                 },
                 "version": {
                     "type": "string",

--- a/helm/idol-omnigroupserver/values.schema.json
+++ b/helm/idol-omnigroupserver/values.schema.json
@@ -125,8 +125,7 @@
             "type": "object",
             "properties":{
                 "registry": {
-                    "type": "string",
-                    "format": "hostname"
+                    "$ref": "#/$defs/required_string"
                 },
                 "version": {
                     "$ref": "#/$defs/required_string"

--- a/helm/idol-qms/values.schema.json
+++ b/helm/idol-qms/values.schema.json
@@ -129,8 +129,7 @@
             "type": "object",
             "properties":{
                 "registry": {
-                    "type": "string",
-                    "format": "hostname"
+                    "$ref": "#/$defs/required_string"
                 },
                 "version": {
                     "$ref": "#/$defs/required_string"

--- a/helm/idol-view/values.schema.json
+++ b/helm/idol-view/values.schema.json
@@ -123,8 +123,7 @@
             "type": "object",
             "properties":{
                 "registry": {
-                    "type": "string",
-                    "format": "hostname"
+                    "$ref": "#/$defs/required_string"
                 },
                 "version": {
                     "$ref": "#/$defs/required_string"

--- a/helm/single-content/values.schema.json
+++ b/helm/single-content/values.schema.json
@@ -127,8 +127,7 @@
             "type": "object",
             "properties":{
                 "registry": {
-                    "type": "string",
-                    "format": "hostname"
+                    "$ref": "#/$defs/required_string"
                 },
                 "version": {
                     "$ref": "#/$defs/required_string"


### PR DESCRIPTION
This facilitates keeping the same image name held
in different repo locations (e.g. microfocusidolserver -> companyrepo/idol/)