### PR TITLE
helm/Idol-nifi: support additional extensions

### DIFF
--- a/helm/idol-nifi/README.md
+++ b/helm/idol-nifi/README.md
@@ -65,6 +65,11 @@ nifiRegistry:
     - "/flows/flow2.json"
 ```
 
+## Providing additional NiFi extension files
+
+Startup scripts matching the pattern `/opt/nifi/nifi-current/prestart_scripts/*.sh` will be run during pod startup, a directory containing any scripts to be run should be mounted to
+`/opt/nifi/nifi-current/prestart_scripts/`. Additional NiFi Archive (NAR) extension files can be provided by utilizing a prestart script that loads the required extension files into the `/opt/nifi/nifi-current/extensions` directory. If a startup script is used to download extensions from an external source, `nifi.allowedStartupSeconds` may need to be increased to allow time for the files to be downloaded. Files in the `/opt/nifi/nifi-current/extensions` directory are persited in the `state-data` persistent volume, allowing for repeated downloads on pod restarts to be avoided.
+
 ## Scaling NiFi
 
 When `nifi.autoScaling.enabled` is set to `true`, some considerations must be made in order for the NiFi cluster to usefully scale.
@@ -165,6 +170,7 @@ Each deployment will require a unique name, and ingress points should be manuall
 | metrics-server.args[0] | string | `"--kubelet-insecure-tls"` |  |
 | metrics-server.enabled | bool | `true` | whether to deploy a metrics server instance |
 | name | string | `"idol-nifi"` | used to name statefulset, service, ingress |
+| nifi.allowedStartupSeconds | int | `60` | number of seconds to allow for prestart scripts (optionally mounted to /opt/nifi/nifi-current/prestart_scripts/) to run. |
 | nifi.autoScaling.enabled | bool | `true` | deploy a horizontal pod autoscaler for the nifi statefulset |
 | nifi.autoScaling.maxReplicas | int | `8` | the maximum size of the nifi statefulset |
 | nifi.autoScaling.metrics | list | See below | one or more metrics controlling the horizontal pod autoscaler (https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v2/#HorizontalPodAutoscalerSpec) |

--- a/helm/idol-nifi/README.md
+++ b/helm/idol-nifi/README.md
@@ -145,6 +145,7 @@ Each deployment will require a unique name, and ingress points should be manuall
 | metrics-server.args[0] | string | `"--kubelet-insecure-tls"` |  |
 | metrics-server.enabled | bool | `true` | whether to deploy a metrics server instance |
 | name | string | `"idol-nifi"` | used to name statefulset, service, ingress |
+| nifi.additionalExtensionFiles | list | `[]` | paths to additional NiFi extension files that are copied into the NiFi extensions directory during initialization |
 | nifi.autoScaling.enabled | bool | `true` | deploy a horizontal pod autoscaler for the nifi statefulset |
 | nifi.autoScaling.maxReplicas | int | `8` | the maximum size of the nifi statefulset |
 | nifi.autoScaling.metrics | list | See below | one or more metrics controlling the horizontal pod autoscaler (https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v2/#HorizontalPodAutoscalerSpec) |

--- a/helm/idol-nifi/README.md
+++ b/helm/idol-nifi/README.md
@@ -165,7 +165,6 @@ Each deployment will require a unique name, and ingress points should be manuall
 | metrics-server.args[0] | string | `"--kubelet-insecure-tls"` |  |
 | metrics-server.enabled | bool | `true` | whether to deploy a metrics server instance |
 | name | string | `"idol-nifi"` | used to name statefulset, service, ingress |
-| nifi.additionalExtensionFiles | list | `[]` | paths to additional NiFi extension files that are copied into the NiFi extensions directory during initialization |
 | nifi.autoScaling.enabled | bool | `true` | deploy a horizontal pod autoscaler for the nifi statefulset |
 | nifi.autoScaling.maxReplicas | int | `8` | the maximum size of the nifi statefulset |
 | nifi.autoScaling.metrics | list | See below | one or more metrics controlling the horizontal pod autoscaler (https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v2/#HorizontalPodAutoscalerSpec) |

--- a/helm/idol-nifi/README.md.gotmpl
+++ b/helm/idol-nifi/README.md.gotmpl
@@ -69,6 +69,11 @@ nifiRegistry:
     - "/flows/flow2.json"
 ```
 
+## Providing additional NiFi extension files
+
+Startup scripts matching the pattern `/opt/nifi/nifi-current/prestart_scripts/*.sh` will be run during pod startup, a directory containing any scripts to be run should be mounted to
+`/opt/nifi/nifi-current/prestart_scripts/`. Additional NiFi Archive (NAR) extension files can be provided by utilizing a prestart script that loads the required extension files into the `/opt/nifi/nifi-current/extensions` directory. If a startup script is used to download extensions from an external source, `nifi.allowedStartupSeconds` may need to be increased to allow time for the files to be downloaded. Files in the `/opt/nifi/nifi-current/extensions` directory are persited in the `state-data` persistent volume, allowing for repeated downloads on pod restarts to be avoided.
+
 ## Scaling NiFi
 
 When `nifi.autoScaling.enabled` is set to `true`, some considerations must be made in order for the NiFi cluster to usefully scale.

--- a/helm/idol-nifi/templates/nifi/_container.tpl
+++ b/helm/idol-nifi/templates/nifi/_container.tpl
@@ -79,12 +79,20 @@ lifecycle:
       command:
       - /bin/bash
       - /scripts/preStop.sh
+startupProbe:
+  exec:
+   command:
+     - pgrep
+     - java
+  periodSeconds: 10
+  timeoutSeconds: 10
+  failureThreshold: {{ div ( add $nifiCluster.allowedStartupSeconds 5 ) 10 }}
+  successThreshold: 1
 livenessProbe:
   exec:
    command:
      - pgrep
      - java
-  initialDelaySeconds: 60
   periodSeconds: 30
   timeoutSeconds: 10
   failureThreshold: 3

--- a/helm/idol-nifi/templates/nifi/_container.tpl
+++ b/helm/idol-nifi/templates/nifi/_container.tpl
@@ -122,6 +122,7 @@ securityContext: {{- omit $component.containerSecurityContext "enabled" | toYaml
   "source" "idol-library.aciserver.container.base.v1"
   "destination" "idolnifi.container.base" 
   "volumeMounts" (list (dict "name" "statedata" "mountPath" "/opt/nifi/nifi-current/conf" "subPath" "conf" "readOnly" false)
+                       (dict "name" "statedata" "mountPath" "/opt/nifi/nifi-current/extensions" "subPath" "extensions" "readOnly" false)
                        (dict "name" "statedata" "mountPath" "/opt/nifi/nifi-current/data" "subPath" "data" "readOnly" false)
                        (dict "name" "statedata" "mountPath" "/opt/nifi/nifi-current/run" "subPath" "run" "readOnly" false)
                        (dict "name" "statedata" "mountPath" "/opt/nifi/nifi-current/state" "subPath" "state" "readOnly" false)

--- a/helm/idol-nifi/templates/nifi/nifi.yaml
+++ b/helm/idol-nifi/templates/nifi/nifi.yaml
@@ -55,13 +55,18 @@ spec:
         - |
           if [ -z "$(ls -A -- /mnt/store/nifi/conf)" ]; then
             echo Copying files into conf directory
-            cp -r /opt/nifi/nifi-current/conf/ /mnt/store/nifi/
+            cp -rv /opt/nifi/nifi-current/conf/ /mnt/store/nifi/
           fi
-
+          echo Copying files into extensions directory
+          cp -rnv /opt/nifi/nifi-current/extensions/ /mnt/store/nifi/
         volumeMounts:
         - name: statedata
           mountPath: /mnt/store/nifi/conf
           subPath: conf
+          readOnly: false
+        - name: statedata
+          mountPath: /mnt/store/nifi/extensions
+          subPath: extensions
           readOnly: false
       - name: wait-for-zookeeper
         image: docker.io/busybox:1.36

--- a/helm/idol-nifi/templates/nifi/nifi.yaml
+++ b/helm/idol-nifi/templates/nifi/nifi.yaml
@@ -59,6 +59,9 @@ spec:
           fi
           echo Copying files into extensions directory
           cp -rnv /opt/nifi/nifi-current/extensions/ /mnt/store/nifi/
+        {{- range $nifiCluster.additionalExtensionFiles }}
+          cp -nv {{ . | quote }} /mnt/store/nifi/extensions
+        {{- end }}
         volumeMounts:
         - name: statedata
           mountPath: /mnt/store/nifi/conf
@@ -68,6 +71,9 @@ spec:
           mountPath: /mnt/store/nifi/extensions
           subPath: extensions
           readOnly: false
+        {{- range $root.Values.additionalVolumeMounts }}
+        - {{ toYaml . | indent 10 | trim }}
+        {{- end }}
       - name: wait-for-zookeeper
         image: docker.io/busybox:1.36
         command:

--- a/helm/idol-nifi/templates/nifi/nifi.yaml
+++ b/helm/idol-nifi/templates/nifi/nifi.yaml
@@ -59,9 +59,6 @@ spec:
           fi
           echo Copying files into extensions directory
           cp -rnv /opt/nifi/nifi-current/extensions/ /mnt/store/nifi/
-        {{- range $nifiCluster.additionalExtensionFiles }}
-          cp -nv {{ . | quote }} /mnt/store/nifi/extensions
-        {{- end }}
         volumeMounts:
         - name: statedata
           mountPath: /mnt/store/nifi/conf
@@ -71,9 +68,6 @@ spec:
           mountPath: /mnt/store/nifi/extensions
           subPath: extensions
           readOnly: false
-        {{- range $root.Values.additionalVolumeMounts }}
-        - {{ toYaml . | indent 10 | trim }}
-        {{- end }}
       - name: wait-for-zookeeper
         image: docker.io/busybox:1.36
         command:

--- a/helm/idol-nifi/values.schema.json
+++ b/helm/idol-nifi/values.schema.json
@@ -243,6 +243,10 @@
                 },
                 "registryHost": {
                     "type":"string"
+                },
+                "allowedStartupSeconds": {
+                    "type": "integer",
+                    "minimum": 10
                 }
             }
         },

--- a/helm/idol-nifi/values.schema.json
+++ b/helm/idol-nifi/values.schema.json
@@ -229,13 +229,6 @@
                         "$ref": "#/$defs/Flow"
                     }
                 },
-                "additionalExtensionFiles": {
-                    "type": "array",
-                    "items": {
-                        "type":"string",
-                        "minLength": 1
-                    }
-                },
                 "ingress": {
                     "$ref": "#/$defs/NifiIngress"
                 },

--- a/helm/idol-nifi/values.schema.json
+++ b/helm/idol-nifi/values.schema.json
@@ -229,6 +229,13 @@
                         "$ref": "#/$defs/Flow"
                     }
                 },
+                "additionalExtensionFiles": {
+                    "type": "array",
+                    "items": {
+                        "type":"string",
+                        "minLength": 1
+                    }
+                },
                 "ingress": {
                     "$ref": "#/$defs/NifiIngress"
                 },

--- a/helm/idol-nifi/values.yaml
+++ b/helm/idol-nifi/values.yaml
@@ -169,9 +169,6 @@ nifi:
   - name: "Basic IDOL"
     bucket: "default-bucket"
     version: ""
-    
-  # -- additional NiFi extension files to be copied into the NiFi extensions directory during pod initialization
-  additionalExtensionFiles: []
 
   ingress:
     # -- whether to deploy ingress for nifi

--- a/helm/idol-nifi/values.yaml
+++ b/helm/idol-nifi/values.yaml
@@ -169,6 +169,9 @@ nifi:
   - name: "Basic IDOL"
     bucket: "default-bucket"
     version: ""
+    
+  # -- additional NiFi extension files to be copied into the NiFi extensions directory during pod initialization
+  additionalExtensionFiles: []
 
   ingress:
     # -- whether to deploy ingress for nifi

--- a/helm/idol-nifi/values.yaml
+++ b/helm/idol-nifi/values.yaml
@@ -229,6 +229,8 @@ nifi:
   # -- optional hostname of an existing nifi registry instance.
   # Defaults to the created registry instance when nifiRegistry.enabled=true
   registryHost: ""
+  # -- number of seconds to allow for prestart scripts (optionally mounted to /opt/nifi/nifi-current/prestart_scripts/) to run.
+  allowedStartupSeconds: 60
 
 # -- nifi cluster instances. Each cluster instance inherits values from the nifi section.
 # When more than one cluster is specified, setting a clusterId is required

--- a/helm/test/test_idol_nifi.py
+++ b/helm/test/test_idol_nifi.py
@@ -164,22 +164,6 @@ class TestIdolNifi(unittest.TestCase, HelmChartTestBase):
         }})
         self.assertEqual(objs['ConfigMap']['idol-nifi-env']['data']['NIFI_REGISTRY_HOSTS'], 'nifi-registry')
 
-    def test_additional_extensions(self):
-        objs = self.render_chart(
-            {
-                'nifi': {
-                    "additionalExtensionFiles": [
-                        "/path/to/some/extension.file1",
-                        "/path/to/some/extension.file2"
-                    ]
-                }
-            })
-        self.assertRegex(
-            objs['StatefulSet']['idol-nifi']['spec']['template']['spec']['initContainers'][0]['command'][2],
-            'cp -nv "/path/to/some/extension.file1" /mnt/store/nifi/extensions')
-        self.assertRegex(
-            objs['StatefulSet']['idol-nifi']['spec']['template']['spec']['initContainers'][0]['command'][2],
-            'cp -nv "/path/to/some/extension.file2" /mnt/store/nifi/extensions')
 
 if __name__ == '__main__':
     unittest.main()

--- a/helm/test/test_idol_nifi.py
+++ b/helm/test/test_idol_nifi.py
@@ -164,6 +164,22 @@ class TestIdolNifi(unittest.TestCase, HelmChartTestBase):
         }})
         self.assertEqual(objs['ConfigMap']['idol-nifi-env']['data']['NIFI_REGISTRY_HOSTS'], 'nifi-registry')
 
+    def test_additional_extensions(self):
+        objs = self.render_chart(
+            {
+                'nifi': {
+                    "additionalExtensionFiles": [
+                        "/path/to/some/extension.file1",
+                        "/path/to/some/extension.file2"
+                    ]
+                }
+            })
+        self.assertRegex(
+            objs['StatefulSet']['idol-nifi']['spec']['template']['spec']['initContainers'][0]['command'][2],
+            'cp -nv "/path/to/some/extension.file1" /mnt/store/nifi/extensions')
+        self.assertRegex(
+            objs['StatefulSet']['idol-nifi']['spec']['template']['spec']['initContainers'][0]['command'][2],
+            'cp -nv "/path/to/some/extension.file2" /mnt/store/nifi/extensions')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Persist NiFi extensions in the `statedata` volume
- Copy additional extensions, specified by `nifi.additionalExtensionFiles`, into the persisted extensions directory during the `ensure-conf` init container

Allows NiFi extensions to be imported from any additional volume specified on the container, and persists any manually imported extensions, e.g. from `kubectl cp /my/extension.nar idol-nifi-0:/opt/nifi/nifi-current/extensions/`
