### PR TITLE
idol-nifi: Correct the JSON Flow diff

### DIFF
--- a/helm/idol-nifi/resources/nifi-toolkit-utils.sh
+++ b/helm/idol-nifi/resources/nifi-toolkit-utils.sh
@@ -148,7 +148,7 @@ nifitoolkit_registry_importFlow (){
             LATESTFLOWVERSION=$(${NIFITOOLKITCMD} registry list-flow-versions -u "${NIFI_REGISTRY_URL}" --flowIdentifier "${FLOWID}" -ot json | jq .[-1].version)
             if [ -n "${LATESTFLOWVERSION}" ]; then
                 #Sort, and remove fields added by the import-flow-version process
-                local JQ=(jq -S "del(.snapshotMetadata, .latest, ..|nulls)")
+                local JQ=(jq -S "del(.snapshotMetadata,.latest) | del(..|nulls)")
 
                 echo "[$(date)] Comparing flow ${FLOW_NAME} to latest version (${LATESTFLOWVERSION}) in registry..."
 


### PR DESCRIPTION
Corrects the JQ command used to clean up the flow JSONs before comparison. Resolves an issue where the flow was always deemed as changed.