### PR TITLE
Wait for registry CLI before importing flows

### DIFF
--- a/helm/idol-nifi/resources/nifi-import-flow.sh
+++ b/helm/idol-nifi/resources/nifi-import-flow.sh
@@ -24,6 +24,8 @@ fi
 NIFI_REGISTRY_URL=http://${NIFI_REGISTRY_HOSTS}:18080
 NEW_PROCESS_GROUP_IDS=()
 
+nifitoolkit_registry_waitForCLI "${NIFI_REGISTRY_URL}"
+
 for i in $(seq 0 "${IDOL_NIFI_FLOW_COUNT}");
 do
     if [  "$i" -eq "${IDOL_NIFI_FLOW_COUNT}" ]; then


### PR DESCRIPTION
Fixes erroneous 'Source bucket X not found' errors