### PR TITLE
helm/api-nifi: Fix flow comparison & start flows in parallel

### DIFF
--- a/helm/idol-nifi/resources/nifi-import-flow.sh
+++ b/helm/idol-nifi/resources/nifi-import-flow.sh
@@ -160,54 +160,65 @@ do
 #{{- end }}
         fi
 
-        echo "[$(date)] FLOWFILE ${FLOWFILE} imported to ProcessGroup: ${PROCESSGROUP}."
+        echo "[$(date)] Flow '${FLOWNAME}' imported to ProcessGroup: ${PROCESSGROUP}."
         NEW_PROCESS_GROUP_IDS+=("${PROCESSGROUP}")
     fi
 done
 
-for PROCESS_GROUP_ID in "${NEW_PROCESS_GROUP_IDS[@]}"
-do
-    echo "[$(date)] Starting services in ProcessGroup: ${PROCESS_GROUP_ID}."
-
-    echo "[$(date)] Enabling services"
-    # Some processors can be slow to start up, so be forgiving
-    set +e
-    ${NIFITOOLKITCMD} nifi pg-enable-services -pgid "${PROCESS_GROUP_ID}" -verbose
-    RC=$?
-    if [ 0 != ${RC} ]; then
-        echo "[$(date)] nifi pg-enable-services failed (RC=${RC}). Services/processors may not be started."
-        # but continue
-    fi
-done
-
 if [ 0 != ${#NEW_PROCESS_GROUP_IDS[@]} ]; then
-    echo "[$(date)] Waiting after service start."
-    sleep 30s
-fi
+    for PROCESS_GROUP_ID in "${NEW_PROCESS_GROUP_IDS[@]}"
+    do
+        echo "[$(date)] Starting services in ProcessGroup: ${PROCESS_GROUP_ID}."
 
-for PROCESS_GROUP_ID in "${NEW_PROCESS_GROUP_IDS[@]}"
-do
-    echo "[$(date)] Starting processors in ProcessGroup: ${PROCESS_GROUP_ID}."
-    for i in {1..12} 
-    do 
-        ${NIFITOOLKITCMD} nifi pg-start -pgid "${PROCESS_GROUP_ID}" -verbose
-        sleep 5s
-        NIFISTATUS=$(${NIFITOOLKITCMD} nifi pg-status -pgid "${PROCESS_GROUP_ID}" -ot json)
+        set +e
+        ${NIFITOOLKITCMD} nifi pg-enable-services -pgid "${PROCESS_GROUP_ID}" -verbose
         RC=$?
         if [ 0 != ${RC} ]; then
-            sleep 5s
-            continue
-        fi
-        INVALID=$(echo "${NIFISTATUS}" | jq .invalidCount)
-        STOPPED=$(echo "${NIFISTATUS}" | jq .stoppedCount)
-        RUNNING=$(echo "${NIFISTATUS}" | jq .runningCount)
-        echo "[$(date)] Processor status: ${RUNNING} running, ${STOPPED} stopped, ${INVALID} invalid"
-        if [ "0" == "$((STOPPED+INVALID))" ]; then
-            break
+            echo "[$(date)] nifi pg-enable-services failed (RC=${RC}). Services/processors may not be started."
+            # but continue
         fi
     done
-    ${NIFITOOLKITCMD} nifi pg-status -pgid "${PROCESS_GROUP_ID}" 
-done
+
+    echo "[$(date)] Waiting after service start."
+    sleep 30s
+
+    START_PROCESS_GROUP_IDS=("${NEW_PROCESS_GROUP_IDS[@]}")
+
+    for i in {1..12} 
+    do
+        echo "[$(date)] Starting processors in ProcessGroups: ${START_PROCESS_GROUP_IDS[*]}."
+        for PROCESS_GROUP_ID in "${START_PROCESS_GROUP_IDS[@]}"
+        do
+            ${NIFITOOLKITCMD} nifi pg-start -pgid "${PROCESS_GROUP_ID}" -verbose
+        done
+        sleep 5s
+        for PROCESS_GROUP_ID in "${START_PROCESS_GROUP_IDS[@]}"
+        do
+            echo "[$(date)] Checking processor status in ProcessGroup: ${PROCESS_GROUP_ID}."
+            NIFISTATUS=$(${NIFITOOLKITCMD} nifi pg-status -pgid "${PROCESS_GROUP_ID}" -ot json)
+            RC=$?
+            if [ 0 != ${RC} ]; then
+                continue
+            fi
+            INVALID=$(echo "${NIFISTATUS}" | jq .invalidCount)
+            STOPPED=$(echo "${NIFISTATUS}" | jq .stoppedCount)
+            RUNNING=$(echo "${NIFISTATUS}" | jq .runningCount)
+            echo "[$(date)] Processor status: ${RUNNING} running, ${STOPPED} stopped, ${INVALID} invalid"
+            if [ "0" == "$((STOPPED+INVALID))" ]; then
+                ${NIFITOOLKITCMD} nifi pg-status -pgid "${PROCESS_GROUP_ID}"
+                START_PROCESS_GROUP_IDS=("${START_PROCESS_GROUP_IDS[@]/${PROCESS_GROUP_ID}}")
+            fi
+        done
+        if [ 0 != ${#START_PROCESS_GROUP_IDS[@]} ]; then
+            sleep 5s
+        fi
+    done
+
+    for PROCESS_GROUP_ID in "${NEW_PROCESS_GROUP_IDS[@]}"
+    do
+        ${NIFITOOLKITCMD} nifi pg-status -pgid "${PROCESS_GROUP_ID}"
+    done
+fi
 
 echo "[$(date)] Flow import completed"
 

--- a/helm/idol-nifi/resources/nifi-toolkit-utils.sh
+++ b/helm/idol-nifi/resources/nifi-toolkit-utils.sh
@@ -148,7 +148,7 @@ nifitoolkit_registry_importFlow (){
             LATESTFLOWVERSION=$(${NIFITOOLKITCMD} registry list-flow-versions -u "${NIFI_REGISTRY_URL}" --flowIdentifier "${FLOWID}" -ot json | jq .[-1].version)
             if [ -n "${LATESTFLOWVERSION}" ]; then
                 #Sort, and remove fields added by the import-flow-version process
-                local JQ=(jq -S "del(.snapshotMetadata,.latest) | del(..|nulls)")
+                local JQ=(jq -S 'del(.snapshotMetadata,.latest) | del(..|nulls) | walk(if type=="array" then .|=sort_by(.name?) else . end)')
 
                 echo "[$(date)] Comparing flow ${FLOW_NAME} to latest version (${LATESTFLOWVERSION}) in registry..."
 


### PR DESCRIPTION
- sort flow json arrays by name, resolves issue where NiFi Registry changing the order of array elements would result in a new version of the flow being added every time
- Start process groups and check status in 'parallel' in a single retry loop to reduce startup time