### PR TITLE
idol-nifi: Remove unnecessary use of setHostnameAsFQDN

### DIFF
--- a/helm/idol-nifi/resources/nifi-postStart.sh
+++ b/helm/idol-nifi/resources/nifi-postStart.sh
@@ -25,7 +25,7 @@ logfile=/opt/nifi/nifi-current/logs/post-start.log
     /scripts/security.sh
 
     statefulsetname=${POD_NAME%-*}
-    grep "${statefulsetname}-0." /etc/hostname
+    grep "${statefulsetname}-0" /etc/hostname
     notprimary=$?
     if [ 1 == ${notprimary} ]; then
         echo ["$(date)"] Skipping post-start checks as non-primary instance

--- a/helm/idol-nifi/resources/nifi-preStop.sh
+++ b/helm/idol-nifi/resources/nifi-preStop.sh
@@ -14,7 +14,7 @@
 logfile=/opt/nifi/nifi-current/logs/pre-stop.log
 (
     statefulsetname=${POD_NAME%-*}
-    grep "${statefulsetname}-0." /etc/hostname
+    grep "${statefulsetname}-0" /etc/hostname
     notprimary=$?
     if [ 0 == ${notprimary} ]; then
         echo "[$(date)] Skipping pre-stop as primary instance."

--- a/helm/idol-nifi/templates/nifi-registry/nifi-registry.yaml
+++ b/helm/idol-nifi/templates/nifi-registry/nifi-registry.yaml
@@ -33,7 +33,6 @@ spec:
     spec:
       automountServiceAccountToken: false
       enableServiceLinks: false
-      setHostnameAsFQDN: true
       dnsPolicy: ClusterFirstWithHostNet
       restartPolicy: Always
 {{- if .Values.podSecurityContext.enabled }}

--- a/helm/idol-nifi/templates/nifi/nifi.yaml
+++ b/helm/idol-nifi/templates/nifi/nifi.yaml
@@ -32,7 +32,6 @@ spec:
       terminationGracePeriodSeconds: 90
       automountServiceAccountToken: false
       enableServiceLinks: false
-      setHostnameAsFQDN: true
       dnsPolicy: ClusterFirstWithHostNet
       restartPolicy: Always
       initContainers:

--- a/helm/idol-nifi/templates/zookeeper/zookeeper.yaml
+++ b/helm/idol-nifi/templates/zookeeper/zookeeper.yaml
@@ -35,7 +35,6 @@ spec:
     spec:
       automountServiceAccountToken: false
       enableServiceLinks: false
-      setHostnameAsFQDN: true
       dnsPolicy: ClusterFirstWithHostNet
       restartPolicy: Always
 {{- if $.Values.podSecurityContext.enabled }}


### PR DESCRIPTION
Unnecessary, and causes errors where the hostname is longer than 64 chars