### PR TITLE
Correct connector-aci ingress

### DIFF
--- a/helm/idol-nifi/templates/nifi/ingress-aci.yaml
+++ b/helm/idol-nifi/templates/nifi/ingress-aci.yaml
@@ -47,7 +47,7 @@ spec:
   rules:
   - http:
       paths:
-      - path: {{ print "/" (trimAll "/" (default ( len $.Values.nifiClusters | plural "" $nifiCluster.clusterId) $nifiCluster.ingress.proxyPath)) "/connector-aci/" $pathSuffix | quote }}
+      - path: {{ print (len $.Values.nifiClusters | plural "" (print "/" $nifiCluster.clusterId)) "/connector-aci/" $pathSuffix | quote }}
         pathType: {{ $pathType }}
         backend:
           service:

--- a/helm/idol-nifi/templates/nifi/ingress-metrics.yaml
+++ b/helm/idol-nifi/templates/nifi/ingress-metrics.yaml
@@ -55,7 +55,7 @@ spec:
   rules:
   - http:
       paths:
-      - path: {{ print "/" (trimAll "/" (default ( len $.Values.nifiClusters | plural "" $nifiCluster.clusterId) $nifiCluster.ingress.proxyPath)) "/metrics" $pathSuffix | quote }}
+      - path: {{ print (len $.Values.nifiClusters | plural "" (print "/" $nifiCluster.clusterId)) "/metrics/" $pathSuffix | quote }}
         pathType: {{ $pathType }}
         backend:
           service:

--- a/helm/test/test_idol_nifi.py
+++ b/helm/test/test_idol_nifi.py
@@ -97,7 +97,9 @@ class TestIdolNifi(unittest.TestCase, HelmChartTestBase):
             self.assertEqual(objs['Ingress'][id]['spec']['rules'][0]['http']['paths'][0]['path'], f'/{id}/(.*)')
             self.assertIn(f'proxy_set_header X-ProxyContextPath "/{id}";',
                            objs['Ingress'][id]['metadata']['annotations']['nginx.ingress.kubernetes.io/configuration-snippet'])
+            self.assertEqual(objs['Ingress'][f'{id}-aci']['spec']['rules'][0]['http']['paths'][0]['path'], f'/{id}/connector-aci/(.*)')
         self.assertEqual(objs['Ingress']['nf3']['spec']['rules'][0]['http']['paths'][0]['path'], f'/(.*)')
+        self.assertEqual(objs['Ingress'][f'nf3-aci']['spec']['rules'][0]['http']['paths'][0]['path'], '/nf3/connector-aci/(.*)')
         self.assertNotIn('proxy_set_header X-ProxyContextPath',
                         objs['Ingress']['nf3']['metadata']['annotations']['nginx.ingress.kubernetes.io/configuration-snippet'])
 
@@ -200,6 +202,10 @@ class TestIdolNifi(unittest.TestCase, HelmChartTestBase):
         }})
         self.assertEqual(objs['ConfigMap']['idol-nifi-env']['data']['NIFI_REGISTRY_HOSTS'], 'nifi-registry')
 
+    def test_default_ingress(self):
+        objs = self.render_chart()
+        self.assertEqual(objs['Ingress']['idol-nifi']['spec']['rules'][0]['http']['paths'][0]['path'], '/(.*)')
+        self.assertEqual(objs['Ingress']['idol-nifi-aci']['spec']['rules'][0]['http']['paths'][0]['path'], '/connector-aci/(.*)')
 
 if __name__ == '__main__':
     unittest.main()

--- a/helm/test/test_idol_nifi.py
+++ b/helm/test/test_idol_nifi.py
@@ -98,8 +98,10 @@ class TestIdolNifi(unittest.TestCase, HelmChartTestBase):
             self.assertIn(f'proxy_set_header X-ProxyContextPath "/{id}";',
                            objs['Ingress'][id]['metadata']['annotations']['nginx.ingress.kubernetes.io/configuration-snippet'])
             self.assertEqual(objs['Ingress'][f'{id}-aci']['spec']['rules'][0]['http']['paths'][0]['path'], f'/{id}/connector-aci/(.*)')
+            self.assertEqual(objs['Ingress'][f'{id}-metrics']['spec']['rules'][0]['http']['paths'][0]['path'], f'/{id}/metrics/(.*)')
         self.assertEqual(objs['Ingress']['nf3']['spec']['rules'][0]['http']['paths'][0]['path'], f'/(.*)')
         self.assertEqual(objs['Ingress'][f'nf3-aci']['spec']['rules'][0]['http']['paths'][0]['path'], '/nf3/connector-aci/(.*)')
+        self.assertEqual(objs['Ingress'][f'nf3-metrics']['spec']['rules'][0]['http']['paths'][0]['path'], '/nf3/metrics/(.*)')
         self.assertNotIn('proxy_set_header X-ProxyContextPath',
                         objs['Ingress']['nf3']['metadata']['annotations']['nginx.ingress.kubernetes.io/configuration-snippet'])
 
@@ -206,6 +208,7 @@ class TestIdolNifi(unittest.TestCase, HelmChartTestBase):
         objs = self.render_chart()
         self.assertEqual(objs['Ingress']['idol-nifi']['spec']['rules'][0]['http']['paths'][0]['path'], '/(.*)')
         self.assertEqual(objs['Ingress']['idol-nifi-aci']['spec']['rules'][0]['http']['paths'][0]['path'], '/connector-aci/(.*)')
+        self.assertEqual(objs['Ingress']['idol-nifi-metrics']['spec']['rules'][0]['http']['paths'][0]['path'], '/metrics/(.*)')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Was generating a path of //connector-aci/(.*)
Doesn't need to use the proxyPath (ingress just maps to a port)