### PR TITLE
idol-nifi: call pg-enable-services on child groups

### DIFF
--- a/helm/idol-nifi/resources/nifi-import-flow.sh
+++ b/helm/idol-nifi/resources/nifi-import-flow.sh
@@ -181,14 +181,14 @@ if [ 0 != ${#NEW_PROCESS_GROUP_IDS[@]} ]; then
                 PROCESS_GROUP_ID=${SVCSTART_PROCESS_GROUP_IDS[${PROCESS_GROUP_INDEX}]}
                 echo "[$(date)] Starting services in ProcessGroup: ${PROCESS_GROUP_ID}."
 
-                set +e
-                ${NIFITOOLKITCMD} nifi pg-enable-services -pgid "${PROCESS_GROUP_ID}" -verbose
-                RC=$?
+                RC=
+                nifitoolkit_nifi_enableProcessGroupServices "${PROCESS_GROUP_ID}" RC
+
                 if [ 0 == ${RC} ]; then
                     unset "SVCSTART_PROCESS_GROUP_IDS[${PROCESS_GROUP_INDEX}]"
                     echo "[$(date)] ${#SVCSTART_PROCESS_GROUP_IDS[@]} Remaining ProcessGroups for Service Start: ${SVCSTART_PROCESS_GROUP_IDS[*]}."
                 else
-                    echo "[$(date)] nifi pg-enable-services failed (RC=${RC})."
+                    echo "[$(date)] Service Start failed (RC=${RC})."
                 fi
             done
 

--- a/helm/idol-nifi/resources/nifi-toolkit-utils.sh
+++ b/helm/idol-nifi/resources/nifi-toolkit-utils.sh
@@ -78,6 +78,39 @@ nifitoolkit_nifi_changeProcessGroupVersion() {
     fi
 }
 
+nifitoolkit_nifi_getChildProcessGroups() {
+    local PGID=$1
+    local OUT_PGLIST=$2
+
+    PGLIST=$(${NIFITOOLKITCMD} nifi pg-list -pgid "${PGID}" -ot json | jq -r ".[].id")
+
+    declare -g "$OUT_PGLIST=${PGLIST}"
+}
+
+nifitoolkit_nifi_enableProcessGroupServices() {
+    local PGID=$1
+    local OUT_RC=$2
+    local RESULT=
+
+    set +e
+    ${NIFITOOLKITCMD} nifi pg-enable-services -pgid "${PGID}" -verbose
+    RC=$?
+    if [ 0 == ${RC} ]; then
+        CHILD_PGLIST=
+        nifitoolkit_nifi_getChildProcessGroups "${PGID}" CHILD_PGLIST
+        for CHILD_PGID in $(echo $CHILD_PGLIST); do
+            echo "[$(date)] Starting services in descendent ProcessGroup: ${CHILD_PGID}."
+            CHILD_RC=
+            nifitoolkit_nifi_enableProcessGroupServices "${CHILD_PGID}" CHILD_RC
+            if [ 0 != ${CHILD_RC} ]; then
+                RC=1
+            fi
+        done
+    else
+        echo "[$(date)] nifi pg-enable-services failed (RC=${RC})."
+    fi
+    declare -g "$OUT_RC=${RC}"
+}
 
 #Registry utilities
 nifitoolkit_registry_waitForCLI() {

--- a/helm/idol-nifi/resources/nifi-toolkit-utils.sh
+++ b/helm/idol-nifi/resources/nifi-toolkit-utils.sh
@@ -90,7 +90,6 @@ nifitoolkit_nifi_getChildProcessGroups() {
 nifitoolkit_nifi_enableProcessGroupServices() {
     local PGID=$1
     local OUT_RC=$2
-    local RESULT=
 
     set +e
     ${NIFITOOLKITCMD} nifi pg-enable-services -pgid "${PGID}" -verbose
@@ -98,11 +97,11 @@ nifitoolkit_nifi_enableProcessGroupServices() {
     if [ 0 == ${RC} ]; then
         CHILD_PGLIST=
         nifitoolkit_nifi_getChildProcessGroups "${PGID}" CHILD_PGLIST
-        for CHILD_PGID in $(echo $CHILD_PGLIST); do
+        for CHILD_PGID in $(echo "$CHILD_PGLIST"); do
             echo "[$(date)] Starting services in descendent ProcessGroup: ${CHILD_PGID}."
             CHILD_RC=
             nifitoolkit_nifi_enableProcessGroupServices "${CHILD_PGID}" CHILD_RC
-            if [ 0 != ${CHILD_RC} ]; then
+            if [ 0 != "${CHILD_RC}" ]; then
                 RC=1
             fi
         done


### PR DESCRIPTION
The NiFi Toolkit pg-enable-services does not check that services started correctly if they are defined in a child process group. If the service defined in the child process group is able to be started, all is well, but if the service is still validating, or fails to start for any reason, the service is left disabled. To work around this, after calling pg-enable-services on the root process group for imported flows, recursively call pg-enable-services on all descendant process groups as well.