### PR TITLE
Add workingDir to idol-library

### DIFF
--- a/helm/idol-library-example-test/Chart.yaml
+++ b/helm/idol-library-example-test/Chart.yaml
@@ -18,5 +18,5 @@ description: |
   not intended to be used for any other purpose
 dependencies:
 - name: idol-library
-  version: "0.14.2"
+  version: "0.15.0"
   repository: file://../idol-library

--- a/helm/idol-library-example-test/values.schema.json
+++ b/helm/idol-library-example-test/values.schema.json
@@ -245,6 +245,10 @@
                 "serviceAccountName":{
                     "type": "string",
                     "description": "Optional serviceAccountName for the pods (https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account)"
+                },
+                "workingDir":{
+                    "type": "string",
+                    "description": "Expected working directory for the container. Should only need to change this for a heavily customized image."
                 }
             },
             "required":[
@@ -253,7 +257,8 @@
                 "name",
                 "aciPort",
                 "servicePort",
-                "usingTLS"
+                "usingTLS",
+                "workingDir"
             ]
         },
         "licensing":{

--- a/helm/idol-library-example-test/values.yaml
+++ b/helm/idol-library-example-test/values.yaml
@@ -99,6 +99,10 @@ replicas: 1
 # -- Optional serviceAccountName for the pods (https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account)
 serviceAccountName: ""
 
+# -- Expected working directory for the container.
+# Should only need to change this for a heavily customized image.
+workingDir: "/content"
+
 ##### NETWORKING CONFIGURATION #####
 # This section contains parameters to configure various network-related
 # properties in this chart.

--- a/helm/idol-library/Chart.yaml
+++ b/helm/idol-library/Chart.yaml
@@ -20,4 +20,4 @@ type: library
 
 # This is the chart version. This version number should be incremented each time you publish changes
 # to the chart and its templates, including the app version.
-version: 0.14.3
+version: 0.15.0

--- a/helm/idol-library/templates/aciserver/_container.tpl
+++ b/helm/idol-library/templates/aciserver/_container.tpl
@@ -19,6 +19,7 @@
 {{- $volumeMounts := get . "volumeMounts" | default list -}}
 {{- $ports := get . "ports" | default list -}}
 {{- $mountConfigMap := dig "mountConfigMap" true . -}}
+{{- $workingDir := get $component "workingDir" | default (printf "/%s" (trimPrefix "idol-" $component.name)) -}}
 name: {{ $component.name | quote }}
 image: {{ include "idol-library.idolImage" (dict "root" $root "idolImage" $component.idolImage) }}
 imagePullPolicy: {{ default (default "IfNotPresent" $component.idolImage.imagePullPolicy) $root.Values.global.imagePullPolicy | quote }}
@@ -58,11 +59,11 @@ volumeMounts:
 {{- end }}
 {{- if $root.Values.global.idolOemLicenseSecret }}
 - name: oem-license
-  mountPath: {{ printf "/%s/licensekey.dat" (trimPrefix "idol-" $component.name) }}
+  mountPath: {{ printf "%s/licensekey.dat" $workingDir }}
   subPath: licensekey.dat
   readOnly: true
 - name: oem-license
-  mountPath: {{ printf "/%s/versionkey.dat" (trimPrefix "idol-" $component.name) }}
+  mountPath: {{ printf "%s/versionkey.dat" $workingDir }}
   subPath: versionkey.dat
   readOnly: true
 {{- end }}

--- a/helm/test/test.py
+++ b/helm/test/test.py
@@ -12,6 +12,11 @@ class TestIdolLibraryExample(AciTestBase, StatefulSetTests, unittest.TestCase):
     chartpath = os.path.join('..','idol-library-example-test')
     _kinds = ['Deployment','StatefulSet','Ingress','ConfigMap','Service']
 
+    def test_oem(self):
+        objs = self.render_chart({'global':{'idolOemLicenseSecret':'oem-secret'}, 'workingDir':'/testoem'})
+        volumeMounts = objs['StatefulSet']['idol-aci-test']['spec']['template']['spec']['containers'][0]['volumeMounts']
+        self.assertTrue(any([ { 'name': 'oem-license','mountPath': '/testoem/licensekey.dat',
+            'subPath': 'licensekey.dat'}.items() <= x.items() for x in volumeMounts]))
 
 class TestIdolAnswerServer(AciTestBase, unittest.TestCase):
     chartpath = os.path.join('..','idol-answerserver')


### PR DESCRIPTION
This provides a hook for fixing issue that
changing the chart .name value can result
in OEM licenses not being placed in the
component working directory.

Still requires going through the other charts
and updating them to use this.