### PR TITLE
run nifiProperties and security scripts during pre-start

### DIFF
--- a/helm/idol-nifi/README.md
+++ b/helm/idol-nifi/README.md
@@ -81,8 +81,8 @@ nifiRegistry:
 
 ## Providing additional NiFi extension files
 
-Startup scripts matching the pattern `/opt/nifi/nifi-current/prestart_scripts/*.sh` will be run during pod startup, a directory containing any scripts to be run should be mounted to
-`/opt/nifi/nifi-current/prestart_scripts/`. Additional NiFi Archive (NAR) extension files can be provided by utilizing a prestart script that loads the required extension files into the `/opt/nifi/nifi-current/extensions` directory. If a startup script is used to download extensions from an external source, `nifi.allowedStartupSeconds` may need to be increased to allow time for the files to be downloaded. Files in the `/opt/nifi/nifi-current/extensions` directory are persited in the `state-data` persistent volume, allowing for repeated downloads on pod restarts to be avoided.
+Startup scripts matching the pattern `/prestart_scripts/*.sh` will be run during pod startup, a directory containing any scripts to be run should be mounted to
+`/prestart_scripts/`. Additional NiFi Archive (NAR) extension files can be provided by utilizing a prestart script that loads the required extension files into the `/opt/nifi/nifi-current/extensions` directory. If a startup script is used to download extensions from an external source, `nifi.allowedStartupSeconds` may need to be increased to allow time for the files to be downloaded. Files in the `/opt/nifi/nifi-current/extensions` directory are persited in the `state-data` persistent volume, allowing for repeated downloads on pod restarts to be avoided.
 
 ## Scaling NiFi
 

--- a/helm/idol-nifi/README.md.gotmpl
+++ b/helm/idol-nifi/README.md.gotmpl
@@ -86,8 +86,8 @@ nifiRegistry:
 
 ## Providing additional NiFi extension files
 
-Startup scripts matching the pattern `/opt/nifi/nifi-current/prestart_scripts/*.sh` will be run during pod startup, a directory containing any scripts to be run should be mounted to
-`/opt/nifi/nifi-current/prestart_scripts/`. Additional NiFi Archive (NAR) extension files can be provided by utilizing a prestart script that loads the required extension files into the `/opt/nifi/nifi-current/extensions` directory. If a startup script is used to download extensions from an external source, `nifi.allowedStartupSeconds` may need to be increased to allow time for the files to be downloaded. Files in the `/opt/nifi/nifi-current/extensions` directory are persited in the `state-data` persistent volume, allowing for repeated downloads on pod restarts to be avoided.
+Startup scripts matching the pattern `/prestart_scripts/*.sh` will be run during pod startup, a directory containing any scripts to be run should be mounted to
+`/prestart_scripts/`. Additional NiFi Archive (NAR) extension files can be provided by utilizing a prestart script that loads the required extension files into the `/opt/nifi/nifi-current/extensions` directory. If a startup script is used to download extensions from an external source, `nifi.allowedStartupSeconds` may need to be increased to allow time for the files to be downloaded. Files in the `/opt/nifi/nifi-current/extensions` directory are persited in the `state-data` persistent volume, allowing for repeated downloads on pod restarts to be avoided.
 
 ## Scaling NiFi
 

--- a/helm/idol-nifi/resources/nifi-postStart.sh
+++ b/helm/idol-nifi/resources/nifi-postStart.sh
@@ -21,8 +21,6 @@ logfile=/opt/nifi/nifi-current/logs/post-start.log
         export JAVA_HOME="$JAVA_HOME"
         echo ["$(date)"] Using auto-detected JAVA_HOME: "$JAVA_HOME"
     fi
-    /scripts/nifiProperties.sh
-    /scripts/security.sh
 
     nifitoolkit_nifi_waitForCLI
     nifitoolkit_configure_threads "${IDOL_NIFI_THREADS:-10}"

--- a/helm/idol-nifi/resources/nifi-preStart.sh
+++ b/helm/idol-nifi/resources/nifi-preStart.sh
@@ -1,0 +1,31 @@
+#! /bin/bash
+
+# BEGIN COPYRIGHT NOTICE
+# Copyright 2023 Open Text.
+# 
+# The only warranties for products and services of Open Text and its affiliates and licensors
+# ("Open Text") are as may be set forth in the express warranty statements accompanying such
+# products and services. Nothing herein should be construed as constituting an additional warranty.
+# Open Text shall not be liable for technical or editorial errors or omissions contained herein.
+# The information contained herein is subject to change without notice.
+#
+# END COPYRIGHT NOTICE
+
+logfile=/opt/nifi/nifi-current/logs/pre-start.log
+(
+    if [ -z "${JAVA_HOME}" ]
+    then
+        JAVA_HOME=$(java -XshowSettings:properties -version 2>&1 | grep java.home | cut -d = -f 2 | xargs)
+        export JAVA_HOME="$JAVA_HOME"
+        echo ["$(date)"] Using auto-detected JAVA_HOME: "$JAVA_HOME"
+    fi
+    /scripts/nifiProperties.sh
+    /scripts/security.sh
+
+    for script in /prestart_scripts/*.sh
+    do 
+        [ -f "$script" ] && source "$script"
+    done
+
+    echo ["$(date)"] preStart completed
+) | tee -a ${logfile}

--- a/helm/idol-nifi/templates/nifi/_container.tpl
+++ b/helm/idol-nifi/templates/nifi/_container.tpl
@@ -143,6 +143,7 @@ securityContext: {{- omit $component.containerSecurityContext "enabled" | toYaml
                        (dict "name" "statedata" "mountPath" "/opt/nifi/nifi-current/provenance_repository" "subPath" "provenance_repository" "readOnly" false)
                        (dict "name" "data" "mountPath" "/idol-ingest" "subPath" "idol-ingest" "readOnly" false)
                        (dict "name" "scripts" "mountPath" "/scripts" "readOnly" false)
+                       (dict "name" "prestart-scripts" "mountPath" "/opt/nifi/nifi-current/prestart_scripts" "readOnly" false)
                        (dict "name" "dshm" "mountPath" "/dev/shm" "readOnly" false))
   "mountConfigMap" false
 ) -}}

--- a/helm/idol-nifi/templates/nifi/nifi.yaml
+++ b/helm/idol-nifi/templates/nifi/nifi.yaml
@@ -147,6 +147,7 @@ spec:
   "containers" (list "idolnifi.container")
   "volumes" (list (dict "name" "data" "emptyDir" (dict "sizeLimit" "3Gi"))
                   (dict "name" "scripts" "configMap" (dict "name" (print $.Values.name "-scripts") "optional" false "defaultMode" 0755))
+                  (dict "name" "prestart-scripts" "configMap" (dict "name" (print $.Values.name "-prestart-scripts") "optional" false "defaultMode" 0755))
                   (dict "name" "dshm" "emptyDir" (dict "medium" "Memory" "sizeLimit" $nifiCluster.resources.sharedMemory)))
   "addConfigMap" false
 ) -}}

--- a/helm/idol-nifi/templates/nifi/prestart-scripts-configmap.yaml
+++ b/helm/idol-nifi/templates/nifi/prestart-scripts-configmap.yaml
@@ -1,0 +1,19 @@
+# BEGIN COPYRIGHT NOTICE
+# Copyright 2023 Open Text.
+# 
+# The only warranties for products and services of Open Text and its affiliates and licensors
+# ("Open Text") are as may be set forth in the express warranty statements accompanying such
+# products and services. Nothing herein should be construed as constituting an additional warranty.
+# Open Text shall not be liable for technical or editorial errors or omissions contained herein.
+# The information contained herein is subject to change without notice.
+#
+# END COPYRIGHT NOTICE
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $.Values.name }}-prestart-scripts
+  labels: {{- include "idol-library.labels" (dict "root" . "component" .Values.nifi) | nindent 4 -}}
+    app: {{ $.Values.name }}
+data:
+  preStart.sh: |
+{{ tpl (.Files.Get "resources/nifi-preStart.sh") . | indent 4 }}


### PR DESCRIPTION
Avoid race condition around the NiFi base image and our scripts overwriting the nifi.properties file at the same time. Ensures truststore/keystore exist before NiFi is started