### PR TITLE
Support nifiClusters as object

### DIFF
--- a/helm/idol-nifi/templates/_util.tpl
+++ b/helm/idol-nifi/templates/_util.tpl
@@ -25,3 +25,22 @@
         $item }} 
 {{ toYaml $mergedItem }}
 {{- end }}
+
+{{/* Calls a named template for each nifi cluster defined in .Values.nifiClusters
+@param .root The root context
+@param .tpl The name of the template to include
+The template will be called with a copy of the same args plus:
+ nifiCluster: the merged object for this cluster instance
+ nifiClustersLen: the number of clusters total
+*/}}
+{{- define "idolnifi.forEachCluster" }}
+{{- $root := get . "root" | required "idolnifi.forEachCluster: missing root" }}
+{{- $tpl := get . "tpl" | required "idolnifi.forEachCluster: missing tpl" }}
+{{- range $nifiClusterItem := default (list dict) $root.Values.nifiClusters }}
+{{ $nifiCluster := (include "idolnifi.clusterItem" (dict "root" $.root "item" $nifiClusterItem) | fromYaml) }}
+{{ $args := merge (dict "nifiCluster" $nifiCluster 
+                        "nifiClustersLen" (default (list dict) ($.root.Values.nifiClusters) | len ))
+                  ($) }}
+{{ include $.tpl $args }}
+{{- end }}
+{{- end }}

--- a/helm/idol-nifi/templates/_util.tpl
+++ b/helm/idol-nifi/templates/_util.tpl
@@ -36,7 +36,8 @@ The template will be called with a copy of the same args plus:
 {{- define "idolnifi.forEachCluster" }}
 {{- $root := get . "root" | required "idolnifi.forEachCluster: missing root" }}
 {{- $tpl := get . "tpl" | required "idolnifi.forEachCluster: missing tpl" }}
-{{- range $nifiClusterItem := default (list dict) $root.Values.nifiClusters }}
+{{- range $nifiClusterItem := default (list dict) 
+      (include "idol-library.util.range_array_or_map_values" (dict "root" $root "vals" $root.Values.nifiClusters) | fromYamlArray) }}
 {{ $nifiCluster := (include "idolnifi.clusterItem" (dict "root" $.root "item" $nifiClusterItem) | fromYaml) }}
 {{ $args := merge (dict "nifiCluster" $nifiCluster 
                         "nifiClustersLen" (default (list dict) ($.root.Values.nifiClusters) | len ))

--- a/helm/idol-nifi/templates/nifi/configmap-keys.yaml
+++ b/helm/idol-nifi/templates/nifi/configmap-keys.yaml
@@ -8,17 +8,20 @@
 # The information contained herein is subject to change without notice.
 #
 # END COPYRIGHT NOTICE
-{{- range $nifiClusterItem := .Values.nifiClusters }}
-{{ $nifiCluster := (include "idolnifi.clusterItem" (dict "root" $ "item" $nifiClusterItem) | fromYaml) }}
+{{- define "idolnifi.nifi.configmap-keys" }}
+{{ $root := get . "root" | required "idolnifi.nifi.configmap-keys: missing nifiCluster" }}
+{{ $nifiCluster := get . "nifiCluster" | required "idolnifi.nifi.configmap-keys: missing nifiCluster" }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ $nifiCluster.clusterId }}-keys-env
-  labels: {{- include "idol-library.labels" (dict "root" $ "component" $nifiCluster) | nindent 4 -}}
+  labels: {{- include "idol-library.labels" (dict "root" $root "component" $nifiCluster) | nindent 4 -}}
     app: {{ $nifiCluster.clusterId }}
 data:
   KEYSTORE_PASSWORD: {{ $nifiCluster.keystorePassword | default (randAlphaNum 24) | quote }}
   NIFI_SENSITIVE_PROPS_KEY: {{ $nifiCluster.sensitivePropsKey | default (randAlphaNum 24) | quote }}
   TRUSTSTORE_PASSWORD: {{ $nifiCluster.truststorePassword | default (randAlphaNum 24) | quote }}
 {{- end }}
+
+{{- include "idolnifi.forEachCluster" (dict "root" . "tpl" "idolnifi.nifi.configmap-keys") }}

--- a/helm/idol-nifi/templates/nifi/configmap.yaml
+++ b/helm/idol-nifi/templates/nifi/configmap.yaml
@@ -8,8 +8,10 @@
 # The information contained herein is subject to change without notice.
 #
 # END COPYRIGHT NOTICE
-{{- range $nifiClusterItem := .Values.nifiClusters }}
-{{ $nifiCluster := (include "idolnifi.clusterItem" (dict "root" $ "item" $nifiClusterItem) | fromYaml) }}
+{{- define "idolnifi.nifi.configmap" }}
+{{ $root := get . "root" | required "idolnifi.nifi.configmap: missing nifiCluster" }}
+{{ $nifiCluster := get . "nifiCluster" | required "idolnifi.nifi.configmap: missing nifiCluster" }}
+{{ $nifiClustersLen := get . "nifiClustersLen" | required "idolniif.nifi.configmap: missing nifiClustersLen" }}
 {{- $flows := (empty $nifiCluster.flowfile | ternary 
                 (fromYamlArray (include "idol-library.util.range_array_or_map_values" (dict "root" . "vals" $nifiCluster.flows)))
                 (list ( dict "file" $nifiCluster.flowfile "bucket" "default-bucket" "import" true ))
@@ -19,7 +21,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ $nifiCluster.clusterId }}-env
-  labels: {{- include "idol-library.labels" (dict "root" $ "component" $nifiCluster) | nindent 4 -}}
+  labels: {{- include "idol-library.labels" (dict "root" $root "component" $nifiCluster) | nindent 4 -}}
     app: {{ $nifiCluster.clusterId }}
 data:
   JAVA_OPTS: "-XX:UseAVX=0 -Djavax.net.debug=ssl,handshake"
@@ -49,7 +51,7 @@ data:
   NIFI_WEB_HTTPS_PORT: "8443"
 {{- if $nifiCluster.ingress.proxyPath }}
   NIFI_WEB_PROXY_CONTEXT_PATH: {{ $nifiCluster.ingress.proxyPath | quote }}
-{{- else if gt (len $.Values.nifiClusters) 1 }}
+{{- else if gt $nifiClustersLen 1 }}
   NIFI_WEB_PROXY_CONTEXT_PATH: "/{{ $nifiCluster.clusterId }}"
 {{- end }}
 {{- if $nifiCluster.ingress.proxyHost }}
@@ -57,7 +59,7 @@ data:
 {{- end }}
   NIFI_ZK_CONNECT_STRING: "{{ $nifiCluster.clusterId }}-zk:2181"
   NIFI_ZOOKEEPER_CONNECT_STRING: "{{ $nifiCluster.clusterId }}-zk:2181"
-  NIFI_REGISTRY_HOSTS: "{{ coalesce $nifiCluster.registryHost (print $.Values.name "-reg")  }}"
+  NIFI_REGISTRY_HOSTS: "{{ coalesce $nifiCluster.registryHost (print $root.Values.name "-reg")  }}"
   TRUSTSTORE_PATH: "${NIFI_HOME}/keytool/truststore.jks"
   TRUSTSTORE_TYPE: "jks"
   IDOL_NIFI_THREADS: "{{ $nifiCluster.threadCount }}"
@@ -72,3 +74,5 @@ data:
   IDOL_NIFI_FLOW_IMPORT_{{ $i }}: {{ hasKey $flow "import" | ternary $flow.import "true" | quote }}
 {{- end }}
 {{- end -}}
+
+{{- include "idolnifi.forEachCluster" (dict "root" . "tpl" "idolnifi.nifi.configmap") }}

--- a/helm/idol-nifi/templates/nifi/hpa.yaml
+++ b/helm/idol-nifi/templates/nifi/hpa.yaml
@@ -8,15 +8,16 @@
 # The information contained herein is subject to change without notice.
 #
 # END COPYRIGHT NOTICE
-{{- range $nifiClusterItem := .Values.nifiClusters }}
-{{ $nifiCluster := (include "idolnifi.clusterItem" (dict "root" $ "item" $nifiClusterItem) | fromYaml) }}
+{{- define "idolnifi.nifi.hpa" }}
+{{ $root := get . "root" | required "idolnifi.nifi.hpa: missing nifiCluster" }}
+{{ $nifiCluster := get . "nifiCluster" | required "idolnifi.nifi.hpa: missing nifiCluster" }}
 {{- if $nifiCluster.autoScaling.enabled }}
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ $nifiCluster.clusterId }}
-  labels: {{- include "idol-library.labels" (dict "root" $ "component" $nifiCluster) | nindent 4 -}}
+  labels: {{- include "idol-library.labels" (dict "root" $root "component" $nifiCluster) | nindent 4 -}}
     app.kubernetes.io/name: {{ $nifiCluster.clusterId }}
 spec:
   scaleTargetRef:
@@ -37,3 +38,5 @@ spec:
 
 {{- end -}}
 {{- end -}}
+
+{{- include "idolnifi.forEachCluster" (dict "root" . "tpl" "idolnifi.nifi.hpa") }}

--- a/helm/idol-nifi/templates/nifi/ingress-aci.yaml
+++ b/helm/idol-nifi/templates/nifi/ingress-aci.yaml
@@ -8,15 +8,17 @@
 # The information contained herein is subject to change without notice.
 #
 # END COPYRIGHT NOTICE
-{{- range $nifiClusterItem := .Values.nifiClusters }}
-{{ $nifiCluster := (include "idolnifi.clusterItem" (dict "root" $ "item" $nifiClusterItem) | fromYaml) }}
+{{- define "idolnifi.nifi.ingress-aci" }}
+{{ $root := get . "root" | required "idolnifi.nifi.ingress-aci: missing nifiCluster" }}
+{{ $nifiCluster := get . "nifiCluster" | required "idolnifi.nifi.ingress-aci: missing nifiCluster" }}
+{{ $nifiClustersLen := get . "nifiClustersLen" | required "idolniif.nifi.ingress-aci: missing nifiClustersLen" }}
 {{- if $nifiCluster.ingress.enabled -}}
 {{- /*
  nginx ingress needs path capture to achieve prefix type routing
 */}}
 {{- $pathSuffix := "" }}
 {{- $pathType := "Prefix" }}
-{{- if eq $.Values.ingressType "nginx" }}
+{{- if eq $root.Values.ingressType "nginx" }}
 {{- $pathSuffix = "(.*)"}}
 {{- $pathType = "ImplementationSpecific" }}
 {{- end }}
@@ -25,18 +27,18 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $nifiCluster.clusterId }}-aci
-  labels: {{- include "idol-library.labels" (dict "root" $ "component" $nifiCluster) | nindent 4 -}}
+  labels: {{- include "idol-library.labels" (dict "root" $root "component" $nifiCluster) | nindent 4 -}}
   annotations:
-{{- if eq $.Values.ingressType "nginx" }}
+{{- if eq $root.Values.ingressType "nginx" }}
     nginx.ingress.kubernetes.io/rewrite-target: /$1
-    nginx.ingress.kubernetes.io/proxy-body-size: {{ $.Values.ingressProxyBodySize }}
-{{- else if eq $.Values.ingressType "haproxy" }}
+    nginx.ingress.kubernetes.io/proxy-body-size: {{ $root.Values.ingressProxyBodySize }}
+{{- else if eq $root.Values.ingressType "haproxy" }}
     haproxy.router.openshift.io/rewrite-target: / 
-    haproxy.router.openshift.io/proxy-body-size: {{ $.Values.ingressProxyBodySize }}
+    haproxy.router.openshift.io/proxy-body-size: {{ $root.Values.ingressProxyBodySize }}
 {{- end }}
 spec:
-{{- if $.Values.ingressClassName }}
-  ingressClassName: {{ $.Values.ingressClassName }}
+{{- if $root.Values.ingressClassName }}
+  ingressClassName: {{ $root.Values.ingressClassName }}
 {{- end }}
 {{- if $nifiCluster.ingress.aciTLS.secretName }}
   tls:
@@ -47,7 +49,7 @@ spec:
   rules:
   - http:
       paths:
-      - path: {{ print (len $.Values.nifiClusters | plural "" (print "/" $nifiCluster.clusterId)) "/connector-aci/" $pathSuffix | quote }}
+      - path: {{ print ($nifiClustersLen | plural "" (print "/" $nifiCluster.clusterId)) "/connector-aci/" $pathSuffix | quote }}
         pathType: {{ $pathType }}
         backend:
           service:
@@ -63,3 +65,5 @@ spec:
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{ include "idolnifi.forEachCluster" (dict "root" . "tpl" "idolnifi.nifi.ingress-aci" ) }}

--- a/helm/idol-nifi/templates/nifi/ingress-metrics.yaml
+++ b/helm/idol-nifi/templates/nifi/ingress-metrics.yaml
@@ -8,15 +8,17 @@
 # The information contained herein is subject to change without notice.
 #
 # END COPYRIGHT NOTICE
-{{- range $nifiClusterItem := .Values.nifiClusters }}
-{{ $nifiCluster := (include "idolnifi.clusterItem" (dict "root" $ "item" $nifiClusterItem) | fromYaml) }}
-{{- if and $.Values.prometheus.enabled $nifiCluster.ingress.enabled }}
+{{- define "idolnifi.nifi.ingress-metrics" }}
+{{ $root := get . "root" | required "idolnifi.nifi.ingress-metrics: missing nifiCluster" }}
+{{ $nifiCluster := get . "nifiCluster" | required "idolnifi.nifi.ingress-metrics: missing nifiCluster" }}
+{{ $nifiClustersLen := get . "nifiClustersLen" | required "idolniif.nifi.ingress-metrics: missing nifiClustersLen" }}
+{{- if and $root.Values.prometheus.enabled $nifiCluster.ingress.enabled }}
 {{- /*
  nginx ingress needs path capture to achieve prefix type routing
 */}}
 {{- $pathSuffix := "" }}
 {{- $pathType := "Prefix" }}
-{{- if eq $.Values.ingressType "nginx" }}
+{{- if eq $root.Values.ingressType "nginx" }}
 {{- $pathSuffix = "(.*)"}}
 {{- $pathType = "ImplementationSpecific" }}
 {{- end }}
@@ -25,26 +27,26 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $nifiCluster.clusterId }}-metrics
-  labels: {{- include "idol-library.labels" (dict "root" $ "component" $nifiCluster) | nindent 4 -}}
+  labels: {{- include "idol-library.labels" (dict "root" $root "component" $nifiCluster) | nindent 4 -}}
   annotations:
     app.kubernetes.io/name: nifi-metrics
     app.kubernetes.io/part-of: {{ $nifiCluster.clusterId }}
-{{- if eq $.Values.ingressType "nginx" }}
+{{- if eq $root.Values.ingressType "nginx" }}
     nginx.ingress.kubernetes.io/rewrite-target: /metrics$1
-    nginx.ingress.kubernetes.io/proxy-body-size: {{ $.Values.ingressProxyBodySize }}
+    nginx.ingress.kubernetes.io/proxy-body-size: {{ $root.Values.ingressProxyBodySize }}
     nginx.ingress.kubernetes.io/affinity: cookie
     nginx.ingress.kubernetes.io/affinity-mode: persistent
-{{- else if eq $.Values.ingressType "haproxy" }}
+{{- else if eq $root.Values.ingressType "haproxy" }}
     haproxy.router.openshift.io/rewrite-target: /metrics
-    haproxy.router.openshift.io/proxy-body-size: {{ $.Values.ingressProxyBodySize }}
+    haproxy.router.openshift.io/proxy-body-size: {{ $root.Values.ingressProxyBodySize }}
 {{- end }}
 {{/* ingress setup is very dependent on cluster ingress controller so allow user value annotations */ -}}
 {{ with $nifiCluster.ingress.annotations }}
 {{- toYaml . | trim | indent 4 }}
 {{- end }}
 spec:
-{{- if $.Values.ingressClassName }}
-  ingressClassName: {{ $.Values.ingressClassName | quote }}
+{{- if $root.Values.ingressClassName }}
+  ingressClassName: {{ $root.Values.ingressClassName | quote }}
 {{- end }}
 {{- if $nifiCluster.ingress.metricsTLS.secretName }}
   tls:
@@ -55,7 +57,7 @@ spec:
   rules:
   - http:
       paths:
-      - path: {{ print (len $.Values.nifiClusters | plural "" (print "/" $nifiCluster.clusterId)) "/metrics/" $pathSuffix | quote }}
+      - path: {{ print ($nifiClustersLen | plural "" (print "/" $nifiCluster.clusterId)) "/metrics/" $pathSuffix | quote }}
         pathType: {{ $pathType }}
         backend:
           service:
@@ -71,3 +73,5 @@ spec:
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{- include "idolnifi.forEachCluster" (dict "root" . "tpl" "idolnifi.nifi.ingress-metrics") }}

--- a/helm/idol-nifi/templates/nifi/ingress.yaml
+++ b/helm/idol-nifi/templates/nifi/ingress.yaml
@@ -8,15 +8,17 @@
 # The information contained herein is subject to change without notice.
 #
 # END COPYRIGHT NOTICE
-{{- range $nifiClusterItem := .Values.nifiClusters }}
-{{ $nifiCluster := (include "idolnifi.clusterItem" (dict "root" $ "item" $nifiClusterItem) | fromYaml) }}
+{{- define "idolnifi.nifi.ingress" }}
+{{ $root := get . "root" | required "idolnifi.nifi.ingress: missing nifiCluster" }}
+{{ $nifiCluster := get . "nifiCluster" | required "idolnifi.nifi.ingress: missing nifiCluster" }}
+{{ $nifiClustersLen := get . "nifiClustersLen" | required "idolniif.nifi.ingress: missing nifiClustersLen" }}
 {{- if $nifiCluster.ingress.enabled -}}
 {{- /*
  nginx ingress needs path capture to achieve prefix type routing
 */}}
 {{- $pathSuffix := "" }}
 {{- $pathType := "Prefix" }}
-{{- if eq $.Values.ingressType "nginx" }}
+{{- if eq $root.Values.ingressType "nginx" }}
 {{- $pathSuffix = "(.*)"}}
 {{- $pathType = "ImplementationSpecific" }}
 {{- end }}
@@ -25,37 +27,37 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $nifiCluster.clusterId }}
-  labels: {{- include "idol-library.labels" (dict "root" $ "component" $nifiCluster) | nindent 4 -}}
+  labels: {{- include "idol-library.labels" (dict "root" $root "component" $nifiCluster) | nindent 4 -}}
     app: {{ $nifiCluster.clusterId }}
   annotations: 
     app.kubernetes.io/name: {{ $nifiCluster.clusterId }}
     app.kubernetes.io/part-of: {{ $nifiCluster.clusterId }}
-{{- if eq $.Values.ingressType "nginx" }}
+{{- if eq $root.Values.ingressType "nginx" }}
     nginx.ingress.kubernetes.io/rewrite-target: /$1
-    nginx.ingress.kubernetes.io/proxy-body-size: {{ $.Values.ingressProxyBodySize }}
+    nginx.ingress.kubernetes.io/proxy-body-size: {{ $root.Values.ingressProxyBodySize }}
     nginx.ingress.kubernetes.io/affinity: cookie
     nginx.ingress.kubernetes.io/affinity-mode: persistent
     nginx.ingress.kubernetes.io/auth-type: basic
-    nginx.ingress.kubernetes.io/auth-secret: {{ $.Values.name }}-basic-auth
+    nginx.ingress.kubernetes.io/auth-secret: {{ $root.Values.name }}-basic-auth
     nginx.ingress.kubernetes.io/auth-realm: "Authentication Required"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       server_tokens off;
       proxy_pass_header Authorization;
       proxy_set_header Authorization $http_authorization;
-{{- if (trimAll "/" (default ( len $.Values.nifiClusters | plural "" $nifiCluster.clusterId) $nifiCluster.ingress.proxyPath)) }}
-      proxy_set_header X-ProxyContextPath {{ print "/" (trimAll "/" (default ( len $.Values.nifiClusters | plural "" $nifiCluster.clusterId) $nifiCluster.ingress.proxyPath)) | quote }};
+{{- if (trimAll "/" (default ( $nifiClustersLen | plural "" $nifiCluster.clusterId) $nifiCluster.ingress.proxyPath)) }}
+      proxy_set_header X-ProxyContextPath {{ print "/" (trimAll "/" (default ( $nifiClustersLen | plural "" $nifiCluster.clusterId) $nifiCluster.ingress.proxyPath)) | quote }};
 {{- end }}
-{{- else if eq $.Values.ingressType "haproxy" }}
+{{- else if eq $root.Values.ingressType "haproxy" }}
     haproxy.router.openshift.io/rewrite-target: / 
-    haproxy.router.openshift.io/proxy-body-size: {{ $.Values.ingressProxyBodySize }}
+    haproxy.router.openshift.io/proxy-body-size: {{ $root.Values.ingressProxyBodySize }}
 {{- end }}
 {{/* ingress setup is very dependent on cluster ingress controller so allow user value annotations */ -}}
 {{ with $nifiCluster.ingress.annotations }}
 {{- toYaml . | trim | indent 4 }}
 {{- end }}
 spec:
-{{- if $.Values.ingressClassName }}
-  ingressClassName: {{ $.Values.ingressClassName | quote }}
+{{- if $root.Values.ingressClassName }}
+  ingressClassName: {{ $root.Values.ingressClassName | quote }}
 {{- end }}
 {{- if $nifiCluster.ingress.tls.secretName }}
   tls:
@@ -66,7 +68,7 @@ spec:
   rules:
   - http:
       paths:
-      - path: {{ print (default ( len $.Values.nifiClusters | plural "/" (print "/" $nifiCluster.clusterId "/")) $nifiCluster.ingress.proxyPath) $pathSuffix | quote }}
+      - path: {{ print (default ( $nifiClustersLen | plural "/" (print "/" $nifiCluster.clusterId "/")) $nifiCluster.ingress.proxyPath) $pathSuffix | quote }}
         pathType: {{ $pathType }}
         backend:
           service:
@@ -82,3 +84,5 @@ spec:
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{- include "idolnifi.forEachCluster" (dict "root" . "tpl" "idolnifi.nifi.ingress") }}

--- a/helm/idol-nifi/templates/nifi/nifi.yaml
+++ b/helm/idol-nifi/templates/nifi/nifi.yaml
@@ -135,22 +135,24 @@ spec:
           storage: {{ $nifiCluster.dataVolume.volumeSize }}
 {{- end -}}
 
-{{- range $nifiClusterItem := .Values.nifiClusters }}
-{{- $nifiCluster := (include "idolnifi.clusterItem" (dict "root" $ "item" $nifiClusterItem) | fromYaml) }}
+{{- define "idolnifi.statefulset" }}
+{{- $root := get . "root" | required "idolnifi.statefulset: missing root" }}
+{{- $nifiCluster := get . "nifiCluster" | required "idolnifi.statefulset: missing nifiCluster" }}
 ---
 {{ include "idol-library.util.merge" (dict
-  "root" $
+  "root" $root
   "component" $nifiCluster
   "nifiCluster" $nifiCluster
   "source" "idol-library.aciserver.statefulset.base.v1"
   "destination" "idolnifi.statefulset.base" 
   "containers" (list "idolnifi.container")
   "volumes" (list (dict "name" "data" "emptyDir" (dict "sizeLimit" "3Gi"))
-                  (dict "name" "scripts" "configMap" (dict "name" (print $.Values.name "-scripts") "optional" false "defaultMode" 0755))
-                  (dict "name" "prestart-scripts" "configMap" (dict "name" (print $.Values.name "-prestart-scripts") "optional" false "defaultMode" 0755))
+                  (dict "name" "scripts" "configMap" (dict "name" (print $root.Values.name "-scripts") "optional" false "defaultMode" 0755))
+                  (dict "name" "prestart-scripts" "configMap" (dict "name" (print $root.Values.name "-prestart-scripts") "optional" false "defaultMode" 0755))
                   (dict "name" "dshm" "emptyDir" (dict "medium" "Memory" "sizeLimit" $nifiCluster.resources.sharedMemory)))
   "addConfigMap" false
 ) -}}
 {{- end -}}
 
+{{- include "idolnifi.forEachCluster" (dict "root" . "tpl" "idolnifi.statefulset") }}
 

--- a/helm/idol-nifi/templates/nifi/service.yaml
+++ b/helm/idol-nifi/templates/nifi/service.yaml
@@ -8,18 +8,19 @@
 # The information contained herein is subject to change without notice.
 #
 # END COPYRIGHT NOTICE
-{{- range $nifiClusterItem := .Values.nifiClusters }}
-{{ $nifiCluster := (include "idolnifi.clusterItem" (dict "root" $ "item" $nifiClusterItem) | fromYaml) }}
+{{- define "idolnifi.nifi.service" }}
+{{ $root := get . "root" | required "idolnifi.nifi.service: missing nifiCluster" }}
+{{ $nifiCluster := get . "nifiCluster" | required "idolnifi.nifi.service: missing nifiCluster" }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ $nifiCluster.clusterId }}
-  labels: {{- include "idol-library.labels" (dict "root" $ "component" $nifiCluster) | nindent 4 -}}
+  labels: {{- include "idol-library.labels" (dict "root" $root "component" $nifiCluster) | nindent 4 -}}
     app: {{ $nifiCluster.clusterId }}
   annotations:
     app.kubernetes.io/name: {{ $nifiCluster.clusterId }}
-    app.kubernetes.io/part-of: {{ $.Values.name }}
+    app.kubernetes.io/part-of: {{ $root.Values.name }}
 spec:
   type: ClusterIP
   selector:
@@ -60,3 +61,5 @@ spec:
   {{- end }}
   {{- end }}
 {{- end }}
+
+{{- include "idolnifi.forEachCluster" (dict "root" . "tpl" "idolnifi.nifi.service") }}

--- a/helm/idol-nifi/templates/zookeeper/service.yaml
+++ b/helm/idol-nifi/templates/zookeeper/service.yaml
@@ -8,14 +8,15 @@
 # The information contained herein is subject to change without notice.
 #
 # END COPYRIGHT NOTICE
-{{- range $nifiClusterItem := .Values.nifiClusters }}
-{{ $nifiCluster := (include "idolnifi.clusterItem" (dict "root" $ "item" $nifiClusterItem) | fromYaml) }}
+{{- define "idolnifi.zookeeper.service" }}
+{{ $root := get . "root" | required "idolnifi.zookeeper.service: missing root" }}
+{{ $nifiCluster := get . "nifiCluster" | required "idolnifi.zookeeper.service: missing nifiCluster" }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ $nifiCluster.clusterId }}-zk
-  labels: {{- include "idol-library.labels" (dict "root" $ "component" $.Values.zookeeper) | nindent 4 -}}
+  labels: {{- include "idol-library.labels" (dict "root" $root "component" $root.Values.zookeeper) | nindent 4 -}}
     app: {{ $nifiCluster.clusterId }}-zk
   annotations:
     app.kubernetes.io/name: {{ $nifiCluster.clusterId }}-zk
@@ -38,3 +39,5 @@ spec:
     targetPort: 7070
     name: metrics
 {{- end -}}
+
+{{- include "idolnifi.forEachCluster" (dict "root" . "tpl" "idolnifi.zookeeper.service")}}

--- a/helm/idol-nifi/templates/zookeeper/zookeeper.yaml
+++ b/helm/idol-nifi/templates/zookeeper/zookeeper.yaml
@@ -8,14 +8,15 @@
 # The information contained herein is subject to change without notice.
 #
 # END COPYRIGHT NOTICE
-{{- range $nifiClusterItem := .Values.nifiClusters }}
-{{ $nifiCluster := (include "idolnifi.clusterItem" (dict "root" $ "item" $nifiClusterItem) | fromYaml) }}
+{{- define "idolnifi.zookeeper.statefulset" }}
+{{ $root := get . "root" | required "idolnifi.zookeeper.statefulset: missing root" }}
+{{ $nifiCluster := get . "nifiCluster" | required "idolnifi.zookeeper.statefulset: missing nifiCluster" }}
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ $nifiCluster.clusterId }}-zk
-  labels: {{- include "idol-library.labels" (dict "root" $ "component" $.Values.zookeeper) | nindent 4 -}}
+  labels: {{- include "idol-library.labels" (dict "root" $root "component" $root.Values.zookeeper) | nindent 4 -}}
     name: {{ $nifiCluster.clusterId }}-zk
     app: {{ $nifiCluster.clusterId }}-zk
   annotations:
@@ -30,23 +31,23 @@ spec:
       app: {{ $nifiCluster.clusterId }}-zk
   template:
     metadata:
-      labels: {{- include "idol-library.labels" (dict "root" $ "component" $.Values.zookeeper) | nindent 8 -}}
+      labels: {{- include "idol-library.labels" (dict "root" $root "component" $root.Values.zookeeper) | nindent 8 -}}
         app: {{ $nifiCluster.clusterId }}-zk
     spec:
       automountServiceAccountToken: false
       enableServiceLinks: false
       dnsPolicy: ClusterFirstWithHostNet
       restartPolicy: Always
-{{- if $.Values.podSecurityContext.enabled }}
-      securityContext: {{- omit $.Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
+{{- if $root.Values.podSecurityContext.enabled }}
+      securityContext: {{- omit $root.Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
 {{- end }}
       imagePullSecrets:
-{{- range $.Values.global.imagePullSecrets }}
+{{- range $root.Values.global.imagePullSecrets }}
       - name: {{ . }}
 {{- end }}
       containers:
       - name: zookeeper
-        image: {{ $.Values.zookeeper.image }}
+        image: {{ $root.Values.zookeeper.image }}
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 2181
@@ -64,7 +65,7 @@ spec:
             value: "server.1=$(POD_IP):2888:3888;2181"
         envFrom:
           - configMapRef:
-              name: {{ $.Values.name }}-zk-cm
+              name: {{ $root.Values.name }}-zk-cm
               optional: false
         livenessProbe:
           exec:
@@ -84,11 +85,11 @@ spec:
           timeoutSeconds: 10
           failureThreshold: 3
           successThreshold: 1
-        {{- if $.Values.zookeeper.resources }}
-        resources: {{ toYaml $.Values.zookeeper.resources | nindent 10 }}
+        {{- if $root.Values.zookeeper.resources }}
+        resources: {{ toYaml $root.Values.zookeeper.resources | nindent 10 }}
         {{- end }}
-        {{- if $.Values.containerSecurityContext.enabled }}
-        securityContext: {{- omit $.Values.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+        {{- if $root.Values.containerSecurityContext.enabled }}
+        securityContext: {{- omit $root.Values.containerSecurityContext "enabled" | toYaml | nindent 10 }}
           readOnlyRootFilesystem: true
         {{- end }}
         volumeMounts:
@@ -106,3 +107,5 @@ spec:
           emptyDir:
             sizeLimit: 2Gi
 {{- end -}}
+
+{{- include "idolnifi.forEachCluster" (dict "root" . "tpl" "idolnifi.zookeeper.statefulset")}}

--- a/helm/idol-nifi/values.schema.json
+++ b/helm/idol-nifi/values.schema.json
@@ -308,26 +308,56 @@
             "title": "Nifi"
         },
         "NifiCluster": {
-            "type": "array",
-            "minItems": 1,
-            "items": {
-                "type": "object",
-                "unevaluatedProperties": false,
-                "allOf": [
-                    {"$ref":"#/$defs/NifiProperties"},
-                    {
-                        "properties": {
-                        "clusterId":{
-                            "type": "string"
+            "oneOf": [
+             {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                    "type": "object",
+                    "unevaluatedProperties": false,
+                    "allOf": [
+                        {"$ref":"#/$defs/NifiProperties"},
+                        {
+                            "properties": {
+                            "clusterId":{
+                                "type": "string"
+                                }
+                            },
+                            "image": {
+                                "$ref": "#/$defs/idolImage"
                             }
-                        },
-                        "image": {
-                            "$ref": "#/$defs/idolImage"
+                        }
+                    ],
+                    "title": "NifiCluster"
+                }
+            },
+            {
+                "type": "object",
+                "patternProperties":{
+                    "^[-a-zA-Z0-0]{0,63}$":{
+                            "type": "object",
+                            "unevaluatedProperties": false,
+                            "allOf": [
+                                {"$ref":"#/$defs/NifiProperties"},
+                                {
+                                    "properties": {
+                                    "clusterId":{
+                                        "type": "string"
+                                        }
+                                    },
+                                    "image": {
+                                        "$ref": "#/$defs/idolImage"
+                                    }
+                                }
+                            ],
+                            "title": "NifiCluster"
                         }
                     }
-                ],
-                "title": "NifiCluster"
+            },
+            {
+                "type": "null"
             }
+            ]
         },
         "Global":{
             "type": "object",

--- a/helm/idol-nifi/values.yaml
+++ b/helm/idol-nifi/values.yaml
@@ -268,8 +268,8 @@ nifi:
 
 # -- nifi cluster instances. Each cluster instance inherits values from the nifi section.
 # When more than one cluster is specified, setting a clusterId is required
-nifiClusters:
- - {}
+nifiClusters: null
+ 
 
 nifiRegistry:
   # -- whether to deploy a nifi registry instance

--- a/helm/test/test_idol_nifi.py
+++ b/helm/test/test_idol_nifi.py
@@ -172,10 +172,12 @@ class TestIdolNifi(unittest.TestCase, HelmChartTestBase):
                 self.assertEqual(objs['StatefulSet'][k]['spec']['replicas'], v)
     
     def test_multiple_nifi_array(self):
+        ''' Test multiple nifiClusters specified in array form '''
         self._check_multiple_nifi(self.render_chart(
             self._multiple_nifi_values(list(self._multiple_nifi_clusters().values()))))
         
-    def test_multiple_nifi_map(self):
+    def test_multiple_nifi_dict(self):
+        ''' Test multiple nifiClusters specified in dict form '''
         self._check_multiple_nifi(self.render_chart(
             self._multiple_nifi_values(self._multiple_nifi_clusters())))
 

--- a/helm/test/test_idol_nifi.py
+++ b/helm/test/test_idol_nifi.py
@@ -14,77 +14,10 @@ class TestIdolNifi(unittest.TestCase, HelmChartTestBase):
     def setUp(self):
         self._kinds = ['StatefulSet','Ingress','ConfigMap','Service']
 
-    def test_multiple_nifi(self):
-        clusterids = ['nf1','nf2','nf3','testnifi']
-        objs = self.render_chart(
-            {
+    def _multiple_nifi_values(self, nifiClusters):
+        return {
                 'name':'testnifi',
-                'nifiClusters':[
-                    { 'clusterId':'nf1',
-                      'replicas': 1 },
-                    {
-                        'clusterId':'nf2',
-                        'flows':{
-                            'f1':{
-                                'file':'/scripts/flow1.json',
-                                'bucket': 'default-bucket',
-                                'import':True
-                            },
-                            'f2':{
-                                'file':'/scripts/flow2.json',
-                                'bucket': 'other-bucket',
-                                'import':False
-                            },
-                            'f3':{
-                                'name':'Existing Flow',
-                                'bucket':'existing-bucket',
-                                'version':"123"
-                            },
-                            'f4':{
-                                'name':'Existing Flow2',
-                                'bucket':'existing-bucket'
-                            },
-                            'basic-idol':{
-                                'DELETE':True
-                            }
-                        },
-                        'service':{
-                            'additionalPorts':{
-                                'commonPort': {
-                                    'port': -1
-                                }
-                            }
-                        }
-                    },
-                    {
-                        'clusterId':'nf3',
-                        'flowfile':'flow3.json',
-                        'replicas': 0,
-                        'ingress':{
-                           'enabled':True,
-                           'proxyPath':'/',
-                           'tls':{ 'secretName':'' },
-                           'aciTLS':{ 'secretName':'' },
-                           'metricsTLS':{
-                             'secretName':''
-                           }
-                        },
-                         'service':{
-                            'additionalPorts':{
-                                'commonPort': {
-                                    'protocol': 'UDP'
-                                },
-                                'extra-port': {
-                                    'name': 'extra',
-                                    'protocol': 'UDP',
-                                    'port': 2223,
-                                    'targetPort': 2224
-                                }
-                            }
-                        }
-                    },
-                    {}
-                ],
+                'nifiClusters': nifiClusters,
                 "nifi":{
                     "replicas": 2,
                     "service": {
@@ -95,7 +28,79 @@ class TestIdolNifi(unittest.TestCase, HelmChartTestBase):
                         }
                     }
                 }
-            })
+            }
+
+    def _multiple_nifi_clusters(self):
+        return {
+            'nf1': { 'clusterId':'nf1',
+                      'replicas': 1 },
+            'nf2': {
+                'clusterId':'nf2',
+                'flows':{
+                    'f1':{
+                        'file':'/scripts/flow1.json',
+                        'bucket': 'default-bucket',
+                        'import':True
+                    },
+                    'f2':{
+                        'file':'/scripts/flow2.json',
+                        'bucket': 'other-bucket',
+                        'import':False
+                    },
+                    'f3':{
+                        'name':'Existing Flow',
+                        'bucket':'existing-bucket',
+                        'version':"123"
+                    },
+                    'f4':{
+                        'name':'Existing Flow2',
+                        'bucket':'existing-bucket'
+                    },
+                    'basic-idol':{
+                        'DELETE':True
+                    }
+                },
+                'service':{
+                    'additionalPorts':{
+                        'commonPort': {
+                            'port': -1
+                        }
+                    }
+                }
+            },
+            'nf3': {
+                'clusterId':'nf3',
+                'flowfile':'flow3.json',
+                'replicas': 0,
+                'ingress':{
+                    'enabled':True,
+                    'proxyPath':'/',
+                    'tls':{ 'secretName':'' },
+                    'aciTLS':{ 'secretName':'' },
+                    'metricsTLS':{
+                        'secretName':''
+                    }
+                },
+                    'service':{
+                    'additionalPorts':{
+                        'commonPort': {
+                            'protocol': 'UDP'
+                        },
+                        'extra-port': {
+                            'name': 'extra',
+                            'protocol': 'UDP',
+                            'port': 2223,
+                            'targetPort': 2224
+                        }
+                    }
+                }
+            },
+            '_unnamed_': {}
+           }
+
+    def _check_multiple_nifi(self, objs):
+        clusterids = ['nf1','nf2','nf3','testnifi']
+        
         # expected manifests with multiple clusters
         self.assertGreaterEqual(set(objs['StatefulSet'].keys()),
                                 set(['testnifi-reg']+list(chain.from_iterable([[id,f'{id}-zk'] for id in clusterids]))))
@@ -165,6 +170,14 @@ class TestIdolNifi(unittest.TestCase, HelmChartTestBase):
         for k,v in {'nf1':1, 'nf2':2, 'nf3': 0 }.items():
             with self.subTest(f'{k} replicas'):
                 self.assertEqual(objs['StatefulSet'][k]['spec']['replicas'], v)
+    
+    def test_multiple_nifi_array(self):
+        self._check_multiple_nifi(self.render_chart(
+            self._multiple_nifi_values(list(self._multiple_nifi_clusters().values()))))
+        
+    def test_multiple_nifi_map(self):
+        self._check_multiple_nifi(self.render_chart(
+            self._multiple_nifi_values(self._multiple_nifi_clusters())))
 
     def test_default_registry_buckets(self):
         objs = self.render_chart({})


### PR DESCRIPTION
This is aimed at enabling cluster specific overrides to be specified
without having to copy the entire nifiCluster array details (due to Helm
only overwriting arrays compared to object merge)

Have to ensure that `nifiClusters: null` is treated the same as `nifiClusters: [ {} ]`