### PR TITLE
Switch nifi service to Headless

### DIFF
--- a/helm/idol-nifi/templates/nifi/service.yaml
+++ b/helm/idol-nifi/templates/nifi/service.yaml
@@ -23,6 +23,7 @@ metadata:
     app.kubernetes.io/part-of: {{ $root.Values.name }}
 spec:
   type: ClusterIP
+  clusterIP: None
   selector:
     app: {{ $nifiCluster.clusterId }}
   ports:


### PR DESCRIPTION
Kubernetes docs say statefulset needs headless service for network identity of pods. On our dev clusters we didn't see any problems without this, but have now found a cluster where apparently this does hold.

Git history shows we did have a headless service up to #78 when it was removed (questioned at the time but accepted that testing seemed to show it wasn't required).

AFACIT, there aren't any downsides to making this service headless. Ingress still works and other services within the cluster still seem to be able to access the nifi cluster going via the now headless service.

Had some concern that ingress pointed at headless service loses some load balancing, but internet suggests most ingress controllers are using k8s api to get endpoints internally anyway so not resolving to pod via DNS.