### PR TITLE
helm/idol-nifi: fix registry liveness probe

### DIFF
--- a/helm/idol-nifi/templates/nifi-registry/nifi-registry.yaml
+++ b/helm/idol-nifi/templates/nifi-registry/nifi-registry.yaml
@@ -90,8 +90,10 @@ spec:
         livenessProbe:
           exec:
             command:
-              - pgrep
-              - java
+              #Registry image doesn't have pgrep or ps
+              - sh
+              - -c
+              - ls -l /proc/*/exe | grep java
           initialDelaySeconds: 60
           periodSeconds: 30
           timeoutSeconds: 10


### PR DESCRIPTION
The registry image doesn't have pgrep, so use "ls -l /proc/*/exe | grep ..." instead. Resolves issue where the registry pod continually restarts